### PR TITLE
Enable User when setting the password

### DIFF
--- a/cc/keystone/identity/backends/cc_ldap.py
+++ b/cc/keystone/identity/backends/cc_ldap.py
@@ -75,6 +75,8 @@ class Identity(ldap_backend.Identity):
             raise exception.Conflict(_('Cannot change user name'))
 
         if 'password' in user:
+            # Ensure user is enabled when setting the password
+            user['enabled'] = True
             # force LDAP replace
             old_obj['password'] = 'fake'
             LOG.info("User password update %s" % user_id)


### PR DESCRIPTION
Returning CCloud Users are disabled and need to be manually enabled via :

```
openstack user set --enable <user-id>
```
This option Enable Users to login to Elektra and execute cli without manual intervention.