### PR TITLE
Prevent an error if a log message can not be composed

### DIFF
--- a/cc/keystone/auth/plugins/cc_x509.py
+++ b/cc/keystone/auth/plugins/cc_x509.py
@@ -78,7 +78,13 @@ class Base(base.AuthMethodHandler):
         except Exception as e:
             LOG.info("Invalid certificate from %s: %s" % (flask.request.environ.get('REMOTE_ADDR'), e))
             if CONF.debug:
-                LOG.info("%s", crypto.dump_certificate(crypto.FILETYPE_TEXT, cert))
+                try:
+                    LOG.info("%s", crypto.dump_certificate(crypto.FILETYPE_TEXT, cert))
+                except AttributeError:
+                    # there is a bug somewhere that prevents dumping the
+                    # cert info; since this is just a log message, it
+                    # should not block us
+                    LOG.info("Could not decode cert: \"%s\"", cert)
             raise exception.Unauthorized("Authentication failed. No trusted certificate provided: %s" % e)
 
         try:


### PR DESCRIPTION
When getting details about a certificate fails, the x509 auth plugin blows up and keystone gets a useless traceback, breaking all other processes. I cannot find out why exactly it fails, but it fails only when a log message cannot be printed.

Just don't print this log message in this case.