### PR TITLE
Improve exception handling for extracting user creds

### DIFF
--- a/cc/keystone/middleware/lifesaver.py
+++ b/cc/keystone/middleware/lifesaver.py
@@ -12,6 +12,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import json
 import keystone.conf
 from oslo_log import log
 from oslo_middleware import base
@@ -105,8 +106,12 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
                                     domain_info = user_info.get('domain', None)
                                     if domain_info:
                                         domain = domain_info.get('name', None)
+        except json.JSONDecodeError as e:
+            self.logger.error("Invalid JSON format: %s. Path: %s, Method: %s", e, request.path, request.method)
+        except ValueError as e:
+            self.logger.error("Malformed JSON body in request: %s. Path: %s, Method: %s", e, request.path, request.method)
         except Exception as e:
-            self.logger.error("Could not extract credentials from request: %s %s" % (request, e))
+            self.logger.error("Unexpected error while extracting credentials: %s. Path: %s, Method: %s", e, request.path, request.method)
 
         if not user:
             user = ''


### PR DESCRIPTION
Improved Exception Handling.
Specifically if a malformed JSON payload needs to handled.

this is the malformed curl request:
![Pasted image 20250409153134](https://github.com/user-attachments/assets/7135b121-0011-40e7-a05f-c247ca74eac3)

showing up in sentry.
![2025-04-09_16-57](https://github.com/user-attachments/assets/ecfacd3a-6f93-4bf4-b9f5-2daf0d2ff147)


after the patch
![2025-04-09_16-59_v2](https://github.com/user-attachments/assets/3bae021e-bf16-438b-a5fa-f2f84065f861)

![2025-04-09_17-00_v3](https://github.com/user-attachments/assets/319a721e-2852-49bf-a9a5-67beb17bd0a1)



