### PR TITLE
x509: Support client certificates sent by Akamai

### DIFF
--- a/cc/keystone/auth/plugins/cc_x509.py
+++ b/cc/keystone/auth/plugins/cc_x509.py
@@ -81,6 +81,7 @@ class Base(base.AuthMethodHandler):
         """Use HTTP_SSL_CLIENT_CERT to look up the user in the identity backend.
         """
         response_data = {}
+        certificate_header_value = ''
         cert = ''
 
         try:
@@ -118,7 +119,7 @@ class Base(base.AuthMethodHandler):
                     # there is a bug somewhere that prevents dumping the
                     # cert info; since this is just a log message, it
                     # should not block us
-                    LOG.info("Could not decode cert: \"%s\"", cert)
+                    LOG.info("Could not process certificate_header: \"%s\"", certificate_header_value)
             raise exception.Unauthorized("Authentication failed. No trusted certificate provided: %s" % e)
 
         try:

--- a/cc/keystone/auth/plugins/cc_x509.py
+++ b/cc/keystone/auth/plugins/cc_x509.py
@@ -15,6 +15,9 @@
 """Keystone x509 based Authentication Plugin"""
 
 import abc
+import base64
+
+import OpenSSL
 import flask
 
 from oslo_config import cfg
@@ -39,6 +42,37 @@ CONF = cfg.CONF
 LOG = log.getLogger(__name__)
 
 METHOD_NAME = 'external'
+URLENCODED_PEM_CERTIFICATE_PREFIX = b"-----BEGIN%20CERTIFICATE-----%0"
+
+
+
+def parse_certificate(pem_input: str | bytes) -> OpenSSL.crypto.X509:
+    """Parses formatted PEM input into OpenSSL.crypto.X509 certificate.
+
+    Supported PEM input formats:
+    * certificate as formatted by ingress-nginx, see https://github.com/kubernetes/ingress-nginx/blob/f820c51858ac98314ca535e091211ed13f1d5b62/docs/user-guide/nginx-configuration/annotations.md?plain=1#L284)
+    * certificate as formatted by Akamai, see "Cert PEM No Labels" @ https://techdocs.akamai.com/property-mgr/docs/set-var-extraction
+    """
+
+    if isinstance(pem_input, str):
+        pem_input = pem_input.encode()
+
+    if pem_input.startswith(URLENCODED_PEM_CERTIFICATE_PREFIX):
+        # assume ingress-nginx format
+        pem_certificate = unquote_to_bytes(pem_input)
+    else:
+        # otherwise, assume Akamai format
+        pem_data = base64.b64decode(pem_input, validate=True)
+        pem_certificate = b"\n".join([
+            b"-----BEGIN CERTIFICATE-----",
+            pem_data,
+            b"-----END CERTIFICATE-----",
+            b"",
+        ])
+    x509_certificate = crypto.load_certificate(crypto.FILETYPE_PEM, pem_certificate)
+
+    return x509_certificate
+
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -56,8 +90,8 @@ class Base(base.AuthMethodHandler):
                 raise Exception("Certificate has not been validated")
 
             # grab the certificate
-            certificate = flask.request.environ[CONF.cc_x509.certificate_header]
-            cert = crypto.load_certificate(crypto.FILETYPE_PEM, unquote_to_bytes(certificate))
+            certificate_header_value = flask.request.environ[CONF.cc_x509.certificate_header]
+            cert = parse_certificate(certificate_header_value)
 
             # is it stil valid?
             if cert.has_expired():

--- a/cc/keystone/auth/plugins/test_cc_x509.py
+++ b/cc/keystone/auth/plugins/test_cc_x509.py
@@ -44,3 +44,9 @@ Da1dTVdWvf5PiMMpTslDOziEYSOSILKMTBTl"""
         # akamai format
         cert = base64.b64encode(self.pem_data.encode())
         self._assert_parse_certificate(cert)
+
+    def test_b64encoded_pem_without_labels_as_single_line(self):
+        # akamai format where pem data is formatted as a single line
+        cert = "".join(self.pem_data.splitlines())
+        cert = base64.b64encode(cert.encode())
+        self._assert_parse_certificate(cert)

--- a/cc/keystone/auth/plugins/test_cc_x509.py
+++ b/cc/keystone/auth/plugins/test_cc_x509.py
@@ -1,0 +1,46 @@
+import base64
+import unittest
+import urllib.parse
+from OpenSSL import crypto
+
+from .cc_x509 import parse_certificate
+
+class TestParseCertificate(unittest.TestCase):
+    pem_data = """MIIDFzCCAf+gAwIBAgIUUo3uRErHxc+83JX0JOKZUkOMLLMwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQdGVzdC5leGFtcGxlLmNvbTAeFw0yNTA3MTExMDIzMzFa
+Fw0yNjA3MTExMDIzMzFaMBsxGTAXBgNVBAMMEHRlc3QuZXhhbXBsZS5jb20wggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsshnt9IqzS3WnizkLGrC2VUwn
+pkfY7hNczQjXJTSaqaQQZT4oixT32XaySFHetJGYdX3ofgNY6dWLpZSFabBIDQ7U
+yYqLegaWTAcd7jQiNZPqqcRs7ga+ZjXRiYbP5/XV802p9x3CZBRP2cs2PqDuDLbN
+058e8VGhT0ZM9sU3wVymC9x8xVTGbs6XF+UuBxZ9Or1YBv4+v/3t5QsUucuXoD72
+Iz05Ji6CEH5N88o+O2FdfhVrw9nblT74/HfLA1M2GlBmPZ7hB8g6SY/W+IQTxa21
+A3DVmt3YZE7cqS5vATmMvZusXn6cW27gj00RY0uTMcWL4YK3uC06qkZZ2cBzAgMB
+AAGjUzBRMB0GA1UdDgQWBBRV2Asz8DmQ4PqkXXWflMyB06ROpTAfBgNVHSMEGDAW
+gBRV2Asz8DmQ4PqkXXWflMyB06ROpTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQCO0PqYhHbhHHIx6/Z5gpb1AsnM8jIWR9LPKL4dRAwhuyjNOxBT
+YggT1Yg3OrPSPVDbSOO64i5MqFQpVUORkqClXgQOIDVjsc7Afz+zPR+ynfsr82W6
+rjU7jYhkyQNyQGiosHab3dvnYez/ZUyk2EfpOYKr9C78kDKXuvetCvlQDDzPKKRX
+EeEBG+SoQk2mwbudM+rZyVc1wM3Pa57N8hX4Rv+iBQ85WPuyeGjm/e9Ewpx10f2p
+VXHNbWkx7sEu41tgVl+OjN1zpFSHEAQ8NetDBC9BrcWFnjZx0ipTlOWl4Jv4Xf6N
+Da1dTVdWvf5PiMMpTslDOziEYSOSILKMTBTl"""
+    pem_certificate = "\n".join([
+        "-----BEGIN CERTIFICATE-----",
+        pem_data,
+        "-----END CERTIFICATE-----",
+        "",
+    ])
+
+    def _assert_parse_certificate(self, cert):
+        parsed_certificate = parse_certificate(cert)
+        parsed_pem_certificate = crypto.dump_certificate(crypto.FILETYPE_PEM, parsed_certificate).decode()
+        self.assertEqual(self.pem_certificate, parsed_pem_certificate)
+
+    def test_urlencoded_pem(self):
+        # ingress-nginx format
+        cert = urllib.parse.quote(self.pem_certificate)
+        self._assert_parse_certificate(cert)
+
+    def test_b64encoded_pem_without_labels(self):
+        # akamai format
+        cert = base64.b64encode(self.pem_data.encode())
+        self._assert_parse_certificate(cert)


### PR DESCRIPTION
This is an alternative implementation of https://github.com/sapcc/keystone-extensions/pull/12:
* Doesn't use regexp, as it's not really needed
* Uses cheap prefix matching instead of more expensive membership matching in strings
* Does not rely on exception handling
* Encapsulates all parsing logic in a separate function, covered by test cases
