### PR TITLE
1/3 refactor lifesaver middleware with modular architecture

### DIFF
--- a/cc/keystone/cmd/cli.py
+++ b/cc/keystone/cmd/cli.py
@@ -68,7 +68,7 @@ class UserScore(BaseApp):
     def main():
         utils = lifesaver_utils.LifesaverUtils(conf={})
         user = utils.normalize(CONF.command.user)
-        user_score = utils.get_user_score(user)
+        user_score = utils.get_score(user)
 
         print(user_score.get())
 

--- a/cc/keystone/middleware/lifesaver.py
+++ b/cc/keystone/middleware/lifesaver.py
@@ -12,11 +12,17 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+
 import keystone.conf
 from oslo_log import log
 from oslo_middleware import base
+
+from . import lifesaver_logic as logic
 from . import lifesaver_utils as utils
 from . import response
+from .lifesaver_logic import calculate_cost
+from .lifesaver_logic import should_update_score_metadata
+from cc.keystone.middleware import score
 
 CONF = keystone.conf.CONF
 
@@ -45,111 +51,74 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
             self.logger.debug('refill-amount is {0}'.format(self.utils.refill_amount))
             self.logger.debug('status-costs are {0}'.format(self.utils.status_cost))
 
-    def get_user(self, request):
+    def get_subject(self, request):
         """
-        Tries to fetch user and its domain from the request
+        Tries to fetch the rate-limit subject and its domain from the request.
+        The subject can be a user or credential identifier.
         :param request: the clients request
-        :return: a dict with 'user' and 'domain'
+        :return: a dict with 'subject' and 'domain'
         """
 
         # shortcut for version discovery request
         if '/v3/' == request.path:
             return None
 
-        user = None
+        subject = None
         domain = None
 
         try:
-            # grab credentials from an authentication request
-            if '/v3/auth/tokens' == request.path and 'POST' == request.method:
-                body = request.json_body
-                if 'auth' in body:
-                    if 'identity' in body['auth']:
-                        if 'password' in body['auth']['identity']:
-                            if 'user' in body['auth']['identity']['password']:
-                                user = body['auth']['identity']['password']['user'].get('name', None)
-                                if not user:
-                                    user = body['auth']['identity']['password']['user'].get('id', None)
-                                    if user:
-                                        user = 'id-' + user
-                                if 'domain' in body['auth']['identity']['password']['user']:
-                                    domain = body['auth']['identity']['password']['user']['domain'].get('name', None)
-                                    if not domain:
-                                        domain = body['auth']['identity']['password']['user']['domain'].get('id', None)
-                        elif 'application_credential' in body['auth']['identity']:
-                            user = body['auth']['identity']['application_credential'].get('id', None)
-                            if user:
-                                user = 'ac-' + user
-
-            elif (('/v3/s3tokens' == request.path or
-                   '/v3/ec2tokens' == request.path) and
-                  'POST' == request.method):
-                # s3tokens/ec2tokens never contains user id, so use
-                # credential's `access` field to identify it
-                body = request.json_body
-                # the order is taken from EC2_S3_Resource.py in keystone
-                credentials = (
-                    body.get('credentials') or
-                    body.get('credential') or
-                    body.get('ec2Credentials')
-                )
-                if '/v3/s3tokens' == request.path:
-                    prefix = 's3creds'
-                elif '/v3/ec2tokens' == request.path:
-                    prefix = 'ec2creds'
-                if credentials:
-                    try:
-                        user = prefix + '-' + credentials['access']
-                        # ec2tokens and s3tokens API are domain unaware. Lets
-                        # just log it.
-                        domain = 'unknown'
-                        # the message will look like this:
-                        # Blocking request POST /v3/s3tokens, since user \
-                        # b's3creds-123456' b'unknown' has no credit left
-                        # OR 'b'ec2creds-123456 b'unknown' has no credit left
-                    except KeyError:
-                        pass
-
-
-            # grab credentials from an authenticated request
-            if not user or not domain:
-                context = request.environ
-
-                if 'KEYSTONE_AUTH_CONTEXT' in context:
-                    # grab from request env
-                    if not user:
-                        user = context.get('HTTP_X_USER_NAME', None)
-                    if not domain:
-                        domain = context.get('HTTP_X_USER_DOMAIN_NAME', None)
-
-                    # try token info
-                    if not user or not domain:
-                        # grab from token
-                        token_info = context.get('keystone.token_info', None)
-                        if token_info:
-                            token = token_info.get('token', None)
-                            if token:
-                                user_info = token.get('user', None)
-                                if user_info:
-                                    user = user_info.get('name', None)
-                                    domain_info = user_info.get('domain', None)
-                                    if domain_info:
-                                        domain = domain_info.get('name', None)
+            subject, domain = logic.extract_password_auth_credentials(request)
+            if not subject:
+                subject = logic.extract_app_credential(request)
+            if not subject:
+                subject, domain = logic.extract_s3_ec2_credentials(request)
+            if not subject:
+                subject, domain = logic.extract_from_authentication_request(request)
         except Exception as e:
-            self.logger.error("Could not extract credentials from request: %s %s" % (request, e))
+            self.logger.error("Could not extract credentials from request: %s %s %s" % (
+                request.method, request.path, e))
 
-        if not user:
-            user = ''
+        if not subject:
+            subject = ''
         if not domain:
             domain = ''
 
-        return {'user': self.utils.normalize(user), 'domain': self.utils.normalize(domain)}
+        return {'subject': self.utils.normalize(subject), 'domain': self.utils.normalize(domain)}
 
     def process_request(self, request):
         return self.verify_request(request)
 
     def process_response(self, response, request=None):
         return self.verify_request(request, response)
+
+    def get_costs(self, request, response, subject, subject_score):
+        cost = calculate_cost(
+            response.status_code,
+            subject,
+            self.utils.status_cost,
+            self.utils.status_cost
+        )
+
+        # deduct subject credit
+        if cost > 0:
+            # mark request as processed
+            request.environ['lifesaver'] = subject
+            subject_score.reduce(cost)
+            # update score metadata in case the configuration has changed
+            if should_update_score_metadata(
+                subject_score,
+                self.utils.credit,
+                self.utils.refill_time,
+                self.utils.refill_amount
+            ):
+                subject_score.credit = self.utils.credit
+                subject_score.refill_time = self.utils.refill_time
+                subject_score.refill_amount = self.utils.refill_amount
+
+            self.utils.set_score(subject, subject_score)
+            self.logger.info("%s has a remaining credit of %d - request %s %s returned %d" % (
+                subject, subject_score.get(), request.method, request.path,
+                response.status_code))
 
     def verify_request(self, request, response=None):
         """
@@ -160,7 +129,6 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
         """
         result = response
 
-        # skip if not enabled
         if not self.utils.enabled:
             return result
 
@@ -168,59 +136,32 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
         if 'lifesaver' in request.environ:
             return result
 
-        credentials = self.get_user(request)
+        credentials = self.get_subject(request)
         if credentials:
-            # request from allowlisted domain?
-            domain = credentials['domain'].encode('utf8')
+            domain = credentials['domain']
             if domain and credentials['domain'] in self.utils.domain_allowlist:
                 return result
 
-            user = credentials['user'].encode('utf8')
-            if user:
-                # request from allowlisted user?
-                if credentials['user'] in self.utils.user_allowlist:
+            subject = credentials['subject']
+            if subject:
+                # request from allowlisted subject?
+                if credentials['subject'] in self.utils.user_allowlist:
                     return result
 
-                # request from blocklisted user?
-                if credentials['user'] in self.utils.user_blocklist:
-                    self.logger.info("Request from blocklisted user %s rejected" % user)
+                # request from blocklisted subject?
+                if credentials['subject'] in self.utils.user_blocklist:
+                    self.logger.info("Request from blocklisted subject %s rejected" % subject)
                     return self.blocklist_response
 
-                user_score = self.utils.get_user_score(credentials['user'])
+                subject_score: score.Score = self.utils.get_score(credentials['subject'])
 
-                if user_score.get() == 0:
-                    self.logger.info("Blocking request %s %s, since user %s %s has no credit left" % (
-                    request.method, request.path, user, domain))
+                if subject_score.get() <= 0:
+                    self.logger.info("Blocking request %s %s, since subject %s %s has no credit left" % (
+                    request.method, request.path, subject[:30], domain))
                     return self.ratelimit_response
 
                 if response:
-                    status = response.status_code
-
-                    # update user score?
-                    if status >= 400:
-                        # what penalty should be applied?
-                        cost = self.utils.status_cost['default']
-                        if str(status) in self.utils.status_cost:
-                            cost = self.utils.status_cost[str(status)]
-                            # mark request as processed
-                            request.environ['lifesaver'] = user
-
-                        # deduct user credit ?
-                        if int(cost) > 0:
-                            user_score.reduce(int(cost))
-
-                            # update score metadata in case the configuration has changed
-                            if user_score.credit != self.utils.credit:
-                                user_score.credit = self.utils.credit
-                            if user_score.refill_time != self.utils.refill_time:
-                                user_score.refill_time = self.utils.refill_time
-                            if user_score.refill_amount != self.utils.refill_amount:
-                                user_score.refill_amount = self.utils.refill_amount
-
-                            self.utils.set_user_score(credentials['user'], user_score)
-                            self.logger.info("User %s %s has a remaining credit of %d - request %s %s returned %d" % (
-                            user, domain, user_score.get(), request.method, request.path,
-                            status))
+                    self.get_costs(request, response, subject, subject_score)
 
         return result
 

--- a/cc/keystone/middleware/lifesaver.py
+++ b/cc/keystone/middleware/lifesaver.py
@@ -91,7 +91,7 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
     def process_response(self, response, request=None):
         return self.verify_request(request, response)
 
-    def get_costs(self, request, response, subject, subject_score):
+    def get_costs(self, request, response, subject, domain, subject_score):
         cost = calculate_cost(
             response.status_code,
             subject,
@@ -116,9 +116,9 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
                 subject_score.refill_amount = self.utils.refill_amount
 
             self.utils.set_score(subject, subject_score)
-            self.logger.info("%s has a remaining credit of %d - request %s %s returned %d" % (
-                subject, subject_score.get(), request.method, request.path,
-                response.status_code))
+            self.logger.info("%s %s has a remaining credit of %d - request %s %s returned %d" % (
+                            subject, domain, subject_score.get(), request.method, request.path,
+                            response.status_code))
 
     def verify_request(self, request, response=None):
         """
@@ -157,11 +157,11 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
 
                 if subject_score.get() <= 0:
                     self.logger.info("Blocking request %s %s, since subject %s %s has no credit left" % (
-                    request.method, request.path, subject[:30], domain))
+                    request.method, request.path, subject, domain))
                     return self.ratelimit_response
 
                 if response:
-                    self.get_costs(request, response, subject, subject_score)
+                    self.get_costs(request, response, subject, domain, subject_score)
 
         return result
 

--- a/cc/keystone/middleware/lifesaver_logic.py
+++ b/cc/keystone/middleware/lifesaver_logic.py
@@ -1,4 +1,4 @@
-# Copyright 2018 SAP SE
+# Copyright 2026 SAP SE
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/cc/keystone/middleware/lifesaver_logic.py
+++ b/cc/keystone/middleware/lifesaver_logic.py
@@ -1,0 +1,209 @@
+# Copyright 2018 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def extract_password_auth_credentials(request):
+    """
+    Extract user credentials from password authentication request body.
+
+    Args:
+        request: Request object
+    Returns:
+        tuple: (user, domain) or (None, None) if not found
+    """
+    if '/v3/auth/tokens' != request.path or 'POST' != request.method:
+        return None, None
+
+    try:
+        body = request.json_body
+    except Exception:
+        return None, None
+
+    if 'auth' not in body:
+        return None, None
+
+    if 'identity' not in body['auth']:
+        return None, None
+
+    identity = body['auth']['identity']
+    if 'password' not in identity:
+        return None, None
+
+    if 'user' not in identity['password']:
+        return None, None
+
+    user_data = identity['password']['user']
+
+    # Extract user (prefer name, fallback to id with prefix)
+    user = user_data.get('name', None)
+    if not user and 'id' in user_data:
+        user = 'id-' + user_data['id']
+
+    # Extract domain (prefer name, fallback to id)
+    domain = None
+    if 'domain' in user_data:
+        domain = user_data['domain'].get('name', None)
+        if not domain and 'id' in user_data['domain']:
+            domain = user_data['domain']['id']
+
+    return user, domain
+
+
+def extract_app_credential(request):
+    """
+    Extract application credential ID from request body.
+
+    Args:
+        request: Request object
+    Returns:
+        str: Application credential ID with 'ac-' prefix, or None if not found
+    """
+    if '/v3/auth/tokens' != request.path or 'POST' != request.method:
+        return None
+
+    try:
+        body = request.json_body
+    except Exception:
+        return None
+
+    if 'auth' not in body:
+        return None
+
+    if 'identity' not in body['auth']:
+        return None
+
+    identity = body['auth']['identity']
+    if 'application_credential' not in identity:
+        return None
+
+    app_cred_id = identity['application_credential'].get('id', None)
+    if app_cred_id:
+        return 'ac-' + app_cred_id
+
+    return None
+
+
+def extract_s3_ec2_credentials(request):
+    """
+    Extract S3 or EC2 credentials from request body.
+
+    Args:
+        request: Request object
+    Returns:
+        tuple: (user with prefix 's3creds-' or 'ec2creds-', domain) or (None, None) if not found
+    """
+    if (('/v3/s3tokens' == request.path or
+                   '/v3/ec2tokens' == request.path) and
+                  'POST' == request.method):
+
+        try:
+            body = request.json_body
+        except Exception:
+            return None, None
+
+        # The order is taken from EC2_S3_Resource.py in keystone
+        credentials = (
+            body.get('credentials') or
+            body.get('credential') or
+            body.get('ec2Credentials')
+        )
+
+        if not credentials or 'access' not in credentials:
+            return None, None
+
+        # Determine prefix based on path
+        prefix = 's3creds' if request.path == '/v3/s3tokens' else 'ec2creds'
+
+        user = prefix + '-' + credentials['access']
+        domain = 'unknown'  # ec2tokens and s3tokens API are domain unaware
+
+        return user, domain
+    return None, None
+
+
+def extract_from_authentication_request(request):
+    """
+    Extract user identifier and domain from various authentication request types.
+
+    Args:
+        request: Request object
+    Returns:
+        tuple: (user, domain) or (None, None) if not found
+    """
+    context = request.environ
+
+    if 'KEYSTONE_AUTH_CONTEXT' not in context:
+        return None, None
+    # grab from request env
+    user = context.get('HTTP_X_USER_NAME', None)
+    domain = context.get('HTTP_X_USER_DOMAIN_NAME', None)
+
+    # try token info
+    if not user or not domain:
+        # grab from token
+        token_info = context.get('keystone.token_info', None)
+        if token_info:
+            token = token_info.get('token', None)
+            if token:
+                user_info = token.get('user', None)
+                if user_info:
+                    user = user_info.get('name', None)
+                    domain_info = user_info.get('domain', None)
+                    if domain_info:
+                        domain = domain_info.get('name', None)
+
+    return user, domain
+
+
+def calculate_cost(status_code, user_identifier, status_cost_config, token_cost_config):
+    """
+    Calculate the cost for a request based on status code and user type.
+
+    Args:
+        status_code: HTTP status code (int)
+        user_identifier: User string
+        status_cost_config: Dict of status codes to costs for regular users
+        token_cost_config: Dict of status codes to costs for token users (unused in PR1)
+
+    Returns:
+        int: Cost to deduct from user's credit
+    """
+    if status_code < 400:
+        return 0
+
+    cost_table = status_cost_config
+
+    status_str = str(status_code)
+    if status_str in cost_table:
+        return int(cost_table[status_str])
+
+    return int(cost_table.get('default', 1))
+
+
+def should_update_score_metadata(score, current_credit, current_refill_time, current_refill_amount):
+    """
+    Check if score metadata needs updating due to configuration changes.
+
+    Args:
+        score: Score object with credit, refill_time, refill_amount attributes
+        current_credit: Current credit config value
+        current_refill_time: Current refill time config value
+        current_refill_amount: Current refill amount config value
+
+    Returns:
+        bool: True if metadata needs updating
+    """
+    return (score.credit != current_credit or
+            score.refill_time != current_refill_time or
+            score.refill_amount != current_refill_amount)

--- a/cc/keystone/middleware/lifesaver_utils.py
+++ b/cc/keystone/middleware/lifesaver_utils.py
@@ -49,7 +49,7 @@ class LifesaverUtils(object):
             group=group)
         CONF.register_opt(
             cfg.DictOpt('status_cost', default=conf.get('status_cost', "default:1,401:10,403:5,404:0,429:0"),
-                        help='Credit consumption by status'), group=group)
+                        help='Credit consumption by status for users'), group=group)
 
         self.enabled = CONF.lifesaver.enabled.lower() in ['true', '1', 't', 'y', 'yes']
 
@@ -64,20 +64,22 @@ class LifesaverUtils(object):
         self.refill_amount = CONF.lifesaver.refill_amount
         self.status_cost = CONF.lifesaver.status_cost
 
-    def get_memcache_key(self, user):
+    def get_memcache_key(self, user: bytes | str):
+        if isinstance(user, bytes):
+            user = user.decode("utf-8")
         return hashlib.md5(user.encode()).hexdigest()
 
-    def get_user_score(self, user):
+    def get_score(self, user) -> score.Score:
         key = self.get_memcache_key(user)
-        user_score = self.memcached.gets(key)
-        if not user_score:
-            user_score = score.Score(self.credit, self.refill_time, self.refill_amount)
-        return user_score
+        score_result = self.memcached.gets(key)
+        if score_result is None or not isinstance(score_result, score.Score):
+            score_result = score.Score(self.credit, self.refill_time, self.refill_amount)
+        return score_result
 
-    def set_user_score(self, user, user_score):
+    def set_score(self, user, score_result):
         key = self.get_memcache_key(user)
         expiration_time = self.credit * self.refill_time * self.refill_amount
-        self.memcached.set(key, user_score, expiration_time)
+        self.memcached.set(key, score_result, expiration_time)
 
     def normalize(self, string=''):
         return string.strip().upper()

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -1,3 +1,17 @@
+# Copyright 2026 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
 import unittest
 import os
 import importlib.util
@@ -273,7 +287,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         self.assertEqual(domain, 'header-domain')
 
     def test_falls_back_to_token_info_when_headers_incomplete(self):
-        """User from headers is preserved; only missing domain is filled from token info."""
+        """ Test that token info is used when headers are missing or incomplete, even if headers are present """
         class MockRequest:
             environ = {
                 'KEYSTONE_AUTH_CONTEXT': True,
@@ -294,7 +308,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
 
-        # user from headers must not be overwritten by token_info
+        # user from headers will be overwritten by token_info if headers are incomplete
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
 

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -1,0 +1,317 @@
+import unittest
+import os
+import importlib.util
+
+# Load the module directly from file path, bypassing forced
+# package imports that would cause a need for unnecessary mocking.
+module_path = os.path.join(
+    os.path.dirname(__file__),
+    '..',
+    'cc',
+    'keystone',
+    'middleware',
+    'lifesaver_logic.py'
+)
+spec = importlib.util.spec_from_file_location("lifesaver_logic", module_path)
+lifesaver_logic = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lifesaver_logic)
+
+
+class TestExtractPasswordAuthCredentials(unittest.TestCase):
+    """Test extracting credentials from password authentication"""
+
+    def test_extracts_user_and_domain_by_name(self):
+        class MockRequest:
+            path = '/v3/auth/tokens'
+            method = 'POST'
+            json_body = {
+                "auth": {
+                    "identity": {
+                        "password": {
+                            "user": {
+                                "name": "testuser",
+                                "domain": {"name": "TestDomain"}
+                            }
+                        }
+                    }
+                }
+            }
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_password_auth_credentials(request)
+
+        self.assertEqual(user, "testuser")
+        self.assertEqual(domain, "TestDomain")
+
+    def test_extracts_user_and_domain_by_id(self):
+        class MockRequest:
+            path = '/v3/auth/tokens'
+            method = 'POST'
+            json_body = {
+                "auth": {
+                    "identity": {
+                        "password": {
+                            "user": {
+                                "id": "user-123",
+                                "domain": {"id": "domain-456"}
+                            }
+                        }
+                    }
+                }
+            }
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_password_auth_credentials(request)
+
+        self.assertEqual(user, "id-user-123")
+        self.assertEqual(domain, "domain-456")
+
+
+class TestExtractAppCredential(unittest.TestCase):
+    """Test extracting application credentials"""
+
+    def test_extracts_app_credential_id(self):
+        class MockRequest:
+            path = '/v3/auth/tokens'
+            method = 'POST'
+            json_body = {
+                "auth": {
+                    "identity": {
+                        "application_credential": {
+                            "id": "app-cred-789"
+                        }
+                    }
+                }
+            }
+
+        request = MockRequest()
+        result = lifesaver_logic.extract_app_credential(request)
+
+        self.assertEqual(result, "ac-app-cred-789")
+
+
+class TestExtractS3Ec2Credentials(unittest.TestCase):
+    """Test extracting S3/EC2 credentials"""
+
+    def test_extracts_s3_credentials(self):
+        class MockRequest:
+            path = '/v3/s3tokens'
+            method = 'POST'
+            json_body = {"credentials": {"access": "s3-access-key-123"}}
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
+
+        self.assertEqual(user, "s3creds-s3-access-key-123")
+        self.assertEqual(domain, "unknown")
+
+    def test_extracts_ec2_credentials(self):
+        class MockRequest:
+            path = '/v3/ec2tokens'
+            method = 'POST'
+            json_body = {"ec2Credentials": {"access": "ec2-access-key-456"}}
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
+
+        self.assertEqual(user, "ec2creds-ec2-access-key-456")
+        self.assertEqual(domain, "unknown")
+
+
+class TestCalculateCost(unittest.TestCase):
+    """Test cost calculation logic"""
+
+    def test_no_cost_for_2xx_status(self):
+        status_cost = {'default': 1, '401': 10}
+        token_cost = {'default': 1, '401': 10}
+
+        cost = lifesaver_logic.calculate_cost(200, 'SOME-USER', status_cost, token_cost)
+
+        self.assertEqual(cost, 0)
+
+    def test_default_cost_applied_for_404(self):
+        status_cost = {'default': 1, '401': 10}
+        token_cost = {'default': 1, '401': 10}
+
+        cost = lifesaver_logic.calculate_cost(404, 'PASSWORD-USER', status_cost, token_cost)
+
+        self.assertEqual(cost, 1)
+
+    def test_401_uses_status_cost(self):
+        status_cost = {'default': 1, '401': 10}
+        token_cost = {'default': 1, '401': 15}
+
+        cost = lifesaver_logic.calculate_cost(401, 'PASSWORD-USER', status_cost, token_cost)
+
+        self.assertEqual(cost, 10)
+
+    def test_unknown_status_uses_default(self):
+        status_cost = {'default': 5}
+        token_cost = {'default': 3}
+
+        cost = lifesaver_logic.calculate_cost(418, 'PASSWORD-USER', status_cost, token_cost)
+
+        self.assertEqual(cost, 5)
+
+
+class TestShouldUpdateScoreMetadata(unittest.TestCase):
+    """Test score metadata update detection"""
+
+    def test_returns_true_when_credit_changed(self):
+        class MockScore:
+            credit = 50
+            refill_time = 60
+            refill_amount = 5
+
+        score = MockScore()
+
+        result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
+
+        self.assertTrue(result)
+
+    def test_returns_true_when_refill_time_changed(self):
+        class MockScore:
+            credit = 100
+            refill_time = 30
+            refill_amount = 5
+
+        score = MockScore()
+
+        result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
+
+        self.assertTrue(result)
+
+    def test_returns_true_when_refill_amount_changed(self):
+        class MockScore:
+            credit = 100
+            refill_time = 60
+            refill_amount = 3
+
+        score = MockScore()
+
+        result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
+
+        self.assertTrue(result)
+
+    def test_returns_false_when_nothing_changed(self):
+        class MockScore:
+            credit = 100
+            refill_time = 60
+            refill_amount = 5
+
+        score = MockScore()
+
+        result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
+
+        self.assertFalse(result)
+
+
+class TestExtractFromAuthenticationRequest(unittest.TestCase):
+    """Test extracting user from authenticated request"""
+
+    def test_extracts_user_from_request_headers(self):
+        """Test extracting user and domain from HTTP headers"""
+        class MockRequest:
+            environ = {
+                'KEYSTONE_AUTH_CONTEXT': True,
+                'HTTP_X_USER_NAME': 'header-user',
+                'HTTP_X_USER_DOMAIN_NAME': 'header-domain'
+            }
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_from_authentication_request(request)
+
+        self.assertEqual(user, 'header-user')
+        self.assertEqual(domain, 'header-domain')
+
+    def test_extracts_user_from_token_info(self):
+        """Test extracting user and domain from token info when headers not present"""
+        class MockRequest:
+            environ = {
+                'KEYSTONE_AUTH_CONTEXT': True,
+                'keystone.token_info': {
+                    'token': {
+                        'user': {
+                            'name': 'token-user',
+                            'domain': {
+                                'name': 'token-domain'
+                            }
+                        }
+                    }
+                }
+            }
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_from_authentication_request(request)
+
+        self.assertEqual(user, 'token-user')
+        self.assertEqual(domain, 'token-domain')
+
+    def test_prefers_headers_over_token_info(self):
+        """Test that headers take precedence over token info"""
+        class MockRequest:
+            environ = {
+                'KEYSTONE_AUTH_CONTEXT': True,
+                'HTTP_X_USER_NAME': 'header-user',
+                'HTTP_X_USER_DOMAIN_NAME': 'header-domain',
+                'keystone.token_info': {
+                    'token': {
+                        'user': {
+                            'name': 'token-user',
+                            'domain': {
+                                'name': 'token-domain'
+                            }
+                        }
+                    }
+                }
+            }
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_from_authentication_request(request)
+
+        self.assertEqual(user, 'header-user')
+        self.assertEqual(domain, 'header-domain')
+
+    def test_falls_back_to_token_info_when_headers_incomplete(self):
+        """User from headers is preserved; only missing domain is filled from token info."""
+        class MockRequest:
+            environ = {
+                'KEYSTONE_AUTH_CONTEXT': True,
+                'HTTP_X_USER_NAME': 'header-user',
+                # No domain in headers
+                'keystone.token_info': {
+                    'token': {
+                        'user': {
+                            'name': 'token-user',
+                            'domain': {
+                                'name': 'token-domain'
+                            }
+                        }
+                    }
+                }
+            }
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_from_authentication_request(request)
+
+        # user from headers must not be overwritten by token_info
+        self.assertEqual(user, 'token-user')
+        self.assertEqual(domain, 'token-domain')
+
+    def test_returns_none_when_no_auth_context(self):
+        """Test that None is returned when KEYSTONE_AUTH_CONTEXT is missing"""
+        class MockRequest:
+            environ = {
+                'HTTP_X_USER_NAME': 'some-user',
+                'HTTP_X_USER_DOMAIN_NAME': 'some-domain'
+            }
+
+        request = MockRequest()
+        user, domain = lifesaver_logic.extract_from_authentication_request(request)
+
+        self.assertIsNone(user)
+        self.assertIsNone(domain)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR is the first of three that will provide the same logic as the bigger #10 

- Extract rate-limiting logic into separate lifesaver_logic module
- Create dedicated score module with Subject and Score classes
- Rename user-centric APIs to subject-based naming (get_user -> get_subject)
- Include comprehensive unit tests for new logic module

also a mention to @tz3. i reverted your change from this [commit](https://github.com/sapcc/keystone-extensions/commit/687c51b)

this is the logic of the current `stable/2025.1-m3` [branch](https://github.com/sapcc/keystone-extensions/blob/225d920c1b623365588a145319a060242a7b4d9d/cc/keystone/middleware/lifesaver.py#L104) as well. i would also say that we do not mix the origin of user and domain. so if we get both from the header, that is fine. of there is a token and the headers does not provide user or domain we switch for both to the token extraction.

