### PR TITLE
2/3 rate-limit token auth requests under their own memcache slot

### DIFF
--- a/cc/keystone/middleware/lifesaver.py
+++ b/cc/keystone/middleware/lifesaver.py
@@ -21,6 +21,7 @@ from . import lifesaver_logic as logic
 from . import lifesaver_utils as utils
 from . import response
 from .lifesaver_logic import calculate_cost
+from .lifesaver_logic import FTOKENCREDS_PREFIX
 from .lifesaver_logic import should_update_score_metadata
 from cc.keystone.middleware import score
 
@@ -50,11 +51,12 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
             self.logger.debug('refill-time is {0}'.format(self.utils.refill_time))
             self.logger.debug('refill-amount is {0}'.format(self.utils.refill_amount))
             self.logger.debug('status-costs are {0}'.format(self.utils.status_cost))
+            self.logger.debug('token-costs are {0}'.format(self.utils.token_cost))
 
     def get_subject(self, request):
         """
         Tries to fetch the rate-limit subject and its domain from the request.
-        The subject can be a user or credential identifier.
+        The subject can be a user, token, or credential identifier.
         :param request: the clients request
         :return: a dict with 'subject' and 'domain'
         """
@@ -70,6 +72,11 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
             subject, domain = logic.extract_password_auth_credentials(request)
             if not subject:
                 subject = logic.extract_app_credential(request)
+            if not subject:
+                token_id = logic.extract_token_id(request)
+                if token_id:
+                    token_hash = self.utils.hash_token_id(token_id)
+                    subject = FTOKENCREDS_PREFIX + token_hash
             if not subject:
                 subject, domain = logic.extract_s3_ec2_credentials(request)
             if not subject:
@@ -96,7 +103,7 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
             response.status_code,
             subject,
             self.utils.status_cost,
-            self.utils.status_cost
+            self.utils.token_cost
         )
 
         # deduct subject credit

--- a/cc/keystone/middleware/lifesaver_logic.py
+++ b/cc/keystone/middleware/lifesaver_logic.py
@@ -12,6 +12,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import hmac
+import logging
+import socket
+
+LOG = logging.getLogger(__name__)
+
+FTOKENCREDS_PREFIX = 'FTOKENCREDS-'
+
 
 def extract_password_auth_credentials(request):
     """
@@ -94,6 +102,34 @@ def extract_app_credential(request):
     return None
 
 
+def extract_token_id(request):
+    """
+    Extract token ID from request body or headers.
+
+    Args:
+        request: Request object
+    Returns:
+        str: Token ID or None if not found
+    """
+    # Check POST body for token
+    if request.path == '/v3/auth/tokens' and request.method == 'POST':
+        try:
+            body = request.json_body
+            if 'auth' in body and 'identity' in body['auth']:
+                if 'token' in body['auth']['identity']:
+                    return body['auth']['identity']['token'].get('id', None)
+        except Exception:
+            # Failed to parse JSON body
+            pass
+
+    # Check GET headers for token
+    if request.path == '/v3/auth/tokens' and request.method == 'GET':
+        if request.headers and 'X-Subject-Token' in request.headers:
+            return request.headers.get('X-Subject-Token', None)
+
+    return None
+
+
 def extract_s3_ec2_credentials(request):
     """
     Extract S3 or EC2 credentials from request body.
@@ -110,6 +146,7 @@ def extract_s3_ec2_credentials(request):
         try:
             body = request.json_body
         except Exception:
+            # Failed to parse JSON body
             return None, None
 
         # The order is taken from EC2_S3_Resource.py in keystone
@@ -166,24 +203,59 @@ def extract_from_authentication_request(request):
     return user, domain
 
 
+def hash_token_id(token_id: str, secret_key: str, hash_function: str = 'sha512') -> str:
+    """Hash a token ID using HMAC.
+
+    If secret_key is not set, the hostname is used as a fallback and a warning
+    is logged. Token rate-limiting remains active but the hash is less secure.
+
+    Args:
+        token_id: The token ID to hash.
+        secret_key: The secret key for HMAC.
+        hash_function: The hash algorithm to use (default: sha512).
+
+    Returns:
+        The hexadecimal digest of the HMAC hash.
+    """
+    if not secret_key:
+        LOG.warning(
+            "security_compliance.invalid_password_hash_secret_key is not set. "
+            "Token hashing will use the hostname as a fallback secret key. "
+            "This reduces security — please configure a proper secret key."
+        )
+        secret_key = socket.getfqdn()
+
+    return hmac.new(
+        key=secret_key.encode('utf-8'),
+        msg=token_id.encode('utf-8'),
+        digestmod=hash_function
+    ).hexdigest()
+
+
 def calculate_cost(status_code, user_identifier, status_cost_config, token_cost_config):
     """
     Calculate the cost for a request based on status code and user type.
 
     Args:
         status_code: HTTP status code (int)
-        user_identifier: User string
+        user_identifier: User string (used to determine if token-based)
         status_cost_config: Dict of status codes to costs for regular users
-        token_cost_config: Dict of status codes to costs for token users (unused in PR1)
+        token_cost_config: Dict of status codes to costs for token users
 
     Returns:
         int: Cost to deduct from user's credit
     """
+    # No cost for successful responses
     if status_code < 400:
         return 0
 
-    cost_table = status_cost_config
+    # Determine which cost table to use based on user prefix
+    if user_identifier.startswith(FTOKENCREDS_PREFIX):
+        cost_table = token_cost_config
+    else:
+        cost_table = status_cost_config
 
+    # Get cost for this status code, fallback to default
     status_str = str(status_code)
     if status_str in cost_table:
         return int(cost_table[status_str])

--- a/cc/keystone/middleware/lifesaver_utils.py
+++ b/cc/keystone/middleware/lifesaver_utils.py
@@ -19,6 +19,7 @@ import memcache
 from oslo_config import cfg
 
 from . import score
+from .lifesaver_logic import hash_token_id
 
 CONF = keystone.conf.CONF
 
@@ -50,6 +51,9 @@ class LifesaverUtils(object):
         CONF.register_opt(
             cfg.DictOpt('status_cost', default=conf.get('status_cost', "default:1,401:10,403:5,404:0,429:0"),
                         help='Credit consumption by status for users'), group=group)
+        CONF.register_opt(
+            cfg.DictOpt('token_cost', default=conf.get('token_cost', "default:1,401:10,403:5,404:10,429:0"),
+                        help='Credit consumption by status for tokens'), group=group)
 
         self.enabled = CONF.lifesaver.enabled.lower() in ['true', '1', 't', 'y', 'yes']
 
@@ -63,6 +67,7 @@ class LifesaverUtils(object):
         self.refill_time = CONF.lifesaver.refill_seconds
         self.refill_amount = CONF.lifesaver.refill_amount
         self.status_cost = CONF.lifesaver.status_cost
+        self.token_cost = CONF.lifesaver.token_cost
 
     def get_memcache_key(self, user: bytes | str):
         if isinstance(user, bytes):
@@ -83,3 +88,10 @@ class LifesaverUtils(object):
 
     def normalize(self, string=''):
         return string.strip().upper()
+
+    def hash_token_id(self, token_id: str) -> str:
+        return hash_token_id(
+            token_id,
+            secret_key=CONF.security_compliance.invalid_password_hash_secret_key,
+            hash_function=CONF.security_compliance.invalid_password_hash_function,
+        )

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -19,11 +19,11 @@ import importlib.util
 # Load the module directly from file path, bypassing forced
 # package imports that would cause a need for unnecessary mocking.
 module_path = os.path.join(
-    os.path.dirname(__file__),
-    '..',
-    'cc',
-    'keystone',
-    'middleware',
+    os.path.dirname(__file__), 
+    '..', 
+    'cc', 
+    'keystone', 
+    'middleware', 
     'lifesaver_logic.py'
 )
 spec = importlib.util.spec_from_file_location("lifesaver_logic", module_path)
@@ -33,7 +33,7 @@ spec.loader.exec_module(lifesaver_logic)
 
 class TestExtractPasswordAuthCredentials(unittest.TestCase):
     """Test extracting credentials from password authentication"""
-
+    
     def test_extracts_user_and_domain_by_name(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -50,13 +50,13 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-
+        
         self.assertEqual(user, "testuser")
         self.assertEqual(domain, "TestDomain")
-
+    
     def test_extracts_user_and_domain_by_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -73,17 +73,17 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-
+        
         self.assertEqual(user, "id-user-123")
         self.assertEqual(domain, "domain-456")
 
 
 class TestExtractAppCredential(unittest.TestCase):
     """Test extracting application credentials"""
-
+    
     def test_extracts_app_credential_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -102,127 +102,169 @@ class TestExtractAppCredential(unittest.TestCase):
         result = lifesaver_logic.extract_app_credential(request)
 
         self.assertEqual(result, "ac-app-cred-789")
+    
+
+class TestExtractTokenId(unittest.TestCase):
+    """Test extracting token IDs from requests"""
+    
+    def test_extracts_token_from_post_body(self):
+        class MockRequest:
+            path = '/v3/auth/tokens'
+            method = 'POST'
+            json_body = {
+                "auth": {
+                    "identity": {
+                        "token": {"id": "test-token-abc"}
+                    }
+                }
+            }
+            headers = {}
+        
+        request = MockRequest()
+        result = lifesaver_logic.extract_token_id(request)
+        
+        self.assertEqual(result, "test-token-abc")
+    
+    def test_extracts_token_from_get_headers(self):
+        class MockRequest:
+            path = '/v3/auth/tokens'
+            method = 'GET'
+            json_body = {}
+            headers = {'X-Subject-Token': 'header-token-xyz'}
+        
+        request = MockRequest()
+        result = lifesaver_logic.extract_token_id(request)
+        
+        self.assertEqual(result, "header-token-xyz")
 
 
 class TestExtractS3Ec2Credentials(unittest.TestCase):
     """Test extracting S3/EC2 credentials"""
-
+    
     def test_extracts_s3_credentials(self):
         class MockRequest:
             path = '/v3/s3tokens'
             method = 'POST'
             json_body = {"credentials": {"access": "s3-access-key-123"}}
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-
+        
         self.assertEqual(user, "s3creds-s3-access-key-123")
         self.assertEqual(domain, "unknown")
-
+    
     def test_extracts_ec2_credentials(self):
         class MockRequest:
             path = '/v3/ec2tokens'
             method = 'POST'
             json_body = {"ec2Credentials": {"access": "ec2-access-key-456"}}
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-
+        
         self.assertEqual(user, "ec2creds-ec2-access-key-456")
         self.assertEqual(domain, "unknown")
 
 
 class TestCalculateCost(unittest.TestCase):
     """Test cost calculation logic"""
-
+    
     def test_no_cost_for_2xx_status(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 10}
-
+        
         cost = lifesaver_logic.calculate_cost(200, 'SOME-USER', status_cost, token_cost)
-
+        
         self.assertEqual(cost, 0)
-
-    def test_default_cost_applied_for_404(self):
-        status_cost = {'default': 1, '401': 10}
-        token_cost = {'default': 1, '401': 10}
-
+    
+    def test_404_for_token_user_uses_token_cost(self):
+        status_cost = {'default': 1, '404': 0}
+        token_cost = {'default': 1, '404': 10}
+        
+        cost = lifesaver_logic.calculate_cost(404, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER-123', status_cost, token_cost)
+        
+        self.assertEqual(cost, 10)
+    
+    def test_404_for_password_user_uses_status_cost(self):
+        status_cost = {'default': 1, '404': 0}
+        token_cost = {'default': 1, '404': 10}
+        
         cost = lifesaver_logic.calculate_cost(404, 'PASSWORD-USER', status_cost, token_cost)
-
-        self.assertEqual(cost, 1)
-
-    def test_401_uses_status_cost(self):
+        
+        self.assertEqual(cost, 0)
+    
+    def test_401_for_token_user(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 15}
-
-        cost = lifesaver_logic.calculate_cost(401, 'PASSWORD-USER', status_cost, token_cost)
-
-        self.assertEqual(cost, 10)
-
+        
+        cost = lifesaver_logic.calculate_cost(401, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER', status_cost, token_cost)
+        
+        self.assertEqual(cost, 15)
+    
     def test_unknown_status_uses_default(self):
         status_cost = {'default': 5}
         token_cost = {'default': 3}
-
+        
         cost = lifesaver_logic.calculate_cost(418, 'PASSWORD-USER', status_cost, token_cost)
-
+        
         self.assertEqual(cost, 5)
 
 
 class TestShouldUpdateScoreMetadata(unittest.TestCase):
     """Test score metadata update detection"""
-
+    
     def test_returns_true_when_credit_changed(self):
         class MockScore:
             credit = 50
             refill_time = 60
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_true_when_refill_time_changed(self):
         class MockScore:
             credit = 100
             refill_time = 30
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_true_when_refill_amount_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 3
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_false_when_nothing_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertFalse(result)
 
 
 class TestExtractFromAuthenticationRequest(unittest.TestCase):
     """Test extracting user from authenticated request"""
-
+    
     def test_extracts_user_from_request_headers(self):
         """Test extracting user and domain from HTTP headers"""
         class MockRequest:
@@ -231,13 +273,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'header-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'header-domain'
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-
+    
     def test_extracts_user_from_token_info(self):
         """Test extracting user and domain from token info when headers not present"""
         class MockRequest:
@@ -254,13 +296,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-
+    
     def test_prefers_headers_over_token_info(self):
         """Test that headers take precedence over token info"""
         class MockRequest:
@@ -279,13 +321,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-
+    
     def test_falls_back_to_token_info_when_headers_incomplete(self):
         """ Test that token info is used when headers are missing or incomplete, even if headers are present """
         class MockRequest:
@@ -311,7 +353,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         # user from headers will be overwritten by token_info if headers are incomplete
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-
+    
     def test_returns_none_when_no_auth_context(self):
         """Test that None is returned when KEYSTONE_AUTH_CONTEXT is missing"""
         class MockRequest:
@@ -319,12 +361,83 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'some-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'some-domain'
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertIsNone(user)
         self.assertIsNone(domain)
+    
+
+
+class TestHashTokenId(unittest.TestCase):
+    """Test the hash_token_id function"""
+    
+    def test_returns_consistent_hash(self):
+        """Same input always produces the same output"""
+        result1 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        result2 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        
+        self.assertEqual(result1, result2)
+    
+    def test_different_tokens_produce_different_hashes(self):
+        """Different token IDs produce different hashes"""
+        result1 = lifesaver_logic.hash_token_id('token-1', 'secret-key')
+        result2 = lifesaver_logic.hash_token_id('token-2', 'secret-key')
+        
+        self.assertNotEqual(result1, result2)
+    
+    def test_different_keys_produce_different_hashes(self):
+        """Different secret keys produce different hashes"""
+        result1 = lifesaver_logic.hash_token_id('test-token', 'key-1')
+        result2 = lifesaver_logic.hash_token_id('test-token', 'key-2')
+        
+        self.assertNotEqual(result1, result2)
+    
+    def test_default_sha512_produces_128_char_hash(self):
+        """SHA-512 (default) produces a 128-character hex digest"""
+        result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        
+        self.assertEqual(len(result), 128)
+    
+    def test_sha256_produces_64_char_hash(self):
+        """SHA-256 produces a 64-character hex digest"""
+        result = lifesaver_logic.hash_token_id('test-token', 'secret-key', hash_function='sha256')
+        
+        self.assertEqual(len(result), 64)
+    
+    def test_falls_back_to_hostname_when_secret_key_is_none(self):
+        """Falls back to hostname and returns a valid hash when secret key is None"""
+        result = lifesaver_logic.hash_token_id('test-token', None)
+        self.assertTrue(all(c in '0123456789abcdef' for c in result))
+
+    def test_falls_back_to_hostname_when_secret_key_is_empty(self):
+        """Falls back to hostname and returns a valid hash when secret key is empty"""
+        result = lifesaver_logic.hash_token_id('test-token', '')
+        self.assertTrue(all(c in '0123456789abcdef' for c in result))
+
+    def test_fallback_matches_explicit_hostname_key(self):
+        """Hash with missing key equals hash using hostname as key"""
+        import socket
+        result_fallback = lifesaver_logic.hash_token_id('test-token', None)
+        result_hostname = lifesaver_logic.hash_token_id('test-token', socket.getfqdn())
+        self.assertIsNotNone(result_fallback)
+        self.assertNotEqual(result_fallback, '')
+        self.assertEqual(result_fallback, result_hostname)
+
+    def test_logs_warning_when_secret_key_is_missing(self):
+        """Warning is logged when secret key is None or empty"""
+        import logging
+        with self.assertLogs('lifesaver_logic', level=logging.WARNING) as cm:
+            lifesaver_logic.hash_token_id('test-token', None)
+        self.assertTrue(any('invalid_password_hash_secret_key' in line for line in cm.output))
+    
+    def test_returns_hex_string(self):
+        """Returns a valid hexadecimal string"""
+        result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        
+        # Should only contain hex characters
+        self.assertTrue(all(c in '0123456789abcdef' for c in result))
 
 
 if __name__ == '__main__':

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -20,10 +20,10 @@ import importlib.util
 # package imports that would cause a need for unnecessary mocking.
 module_path = os.path.join(
     os.path.dirname(__file__), 
-    '..', 
-    'cc', 
-    'keystone', 
-    'middleware', 
+    '..',
+    'cc',
+    'keystone',
+    'middleware',
     'lifesaver_logic.py'
 )
 spec = importlib.util.spec_from_file_location("lifesaver_logic", module_path)
@@ -33,7 +33,7 @@ spec.loader.exec_module(lifesaver_logic)
 
 class TestExtractPasswordAuthCredentials(unittest.TestCase):
     """Test extracting credentials from password authentication"""
-    
+
     def test_extracts_user_and_domain_by_name(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -50,13 +50,13 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-        
+
         self.assertEqual(user, "testuser")
         self.assertEqual(domain, "TestDomain")
-    
+
     def test_extracts_user_and_domain_by_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -73,17 +73,17 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-        
+
         self.assertEqual(user, "id-user-123")
         self.assertEqual(domain, "domain-456")
 
 
 class TestExtractAppCredential(unittest.TestCase):
     """Test extracting application credentials"""
-    
+
     def test_extracts_app_credential_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -102,11 +102,11 @@ class TestExtractAppCredential(unittest.TestCase):
         result = lifesaver_logic.extract_app_credential(request)
 
         self.assertEqual(result, "ac-app-cred-789")
-    
+
 
 class TestExtractTokenId(unittest.TestCase):
     """Test extracting token IDs from requests"""
-    
+
     def test_extracts_token_from_post_body(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -119,152 +119,152 @@ class TestExtractTokenId(unittest.TestCase):
                 }
             }
             headers = {}
-        
+
         request = MockRequest()
         result = lifesaver_logic.extract_token_id(request)
-        
+
         self.assertEqual(result, "test-token-abc")
-    
+
     def test_extracts_token_from_get_headers(self):
         class MockRequest:
             path = '/v3/auth/tokens'
             method = 'GET'
             json_body = {}
             headers = {'X-Subject-Token': 'header-token-xyz'}
-        
+
         request = MockRequest()
         result = lifesaver_logic.extract_token_id(request)
-        
+
         self.assertEqual(result, "header-token-xyz")
 
 
 class TestExtractS3Ec2Credentials(unittest.TestCase):
     """Test extracting S3/EC2 credentials"""
-    
+
     def test_extracts_s3_credentials(self):
         class MockRequest:
             path = '/v3/s3tokens'
             method = 'POST'
             json_body = {"credentials": {"access": "s3-access-key-123"}}
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-        
+
         self.assertEqual(user, "s3creds-s3-access-key-123")
         self.assertEqual(domain, "unknown")
-    
+
     def test_extracts_ec2_credentials(self):
         class MockRequest:
             path = '/v3/ec2tokens'
             method = 'POST'
             json_body = {"ec2Credentials": {"access": "ec2-access-key-456"}}
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-        
+
         self.assertEqual(user, "ec2creds-ec2-access-key-456")
         self.assertEqual(domain, "unknown")
 
 
 class TestCalculateCost(unittest.TestCase):
     """Test cost calculation logic"""
-    
+
     def test_no_cost_for_2xx_status(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 10}
-        
+
         cost = lifesaver_logic.calculate_cost(200, 'SOME-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 0)
-    
+
     def test_404_for_token_user_uses_token_cost(self):
         status_cost = {'default': 1, '404': 0}
         token_cost = {'default': 1, '404': 10}
-        
+
         cost = lifesaver_logic.calculate_cost(404, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER-123', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 10)
-    
+
     def test_404_for_password_user_uses_status_cost(self):
         status_cost = {'default': 1, '404': 0}
         token_cost = {'default': 1, '404': 10}
-        
+
         cost = lifesaver_logic.calculate_cost(404, 'PASSWORD-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 0)
-    
+
     def test_401_for_token_user(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 15}
-        
+
         cost = lifesaver_logic.calculate_cost(401, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 15)
-    
+
     def test_unknown_status_uses_default(self):
         status_cost = {'default': 5}
         token_cost = {'default': 3}
-        
+
         cost = lifesaver_logic.calculate_cost(418, 'PASSWORD-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 5)
 
 
 class TestShouldUpdateScoreMetadata(unittest.TestCase):
     """Test score metadata update detection"""
-    
+
     def test_returns_true_when_credit_changed(self):
         class MockScore:
             credit = 50
             refill_time = 60
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_true_when_refill_time_changed(self):
         class MockScore:
             credit = 100
             refill_time = 30
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_true_when_refill_amount_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 3
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_false_when_nothing_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertFalse(result)
 
 
 class TestExtractFromAuthenticationRequest(unittest.TestCase):
     """Test extracting user from authenticated request"""
-    
+
     def test_extracts_user_from_request_headers(self):
         """Test extracting user and domain from HTTP headers"""
         class MockRequest:
@@ -273,13 +273,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'header-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'header-domain'
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-    
+
     def test_extracts_user_from_token_info(self):
         """Test extracting user and domain from token info when headers not present"""
         class MockRequest:
@@ -296,13 +296,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-    
+
     def test_prefers_headers_over_token_info(self):
         """Test that headers take precedence over token info"""
         class MockRequest:
@@ -321,13 +321,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-    
+
     def test_falls_back_to_token_info_when_headers_incomplete(self):
         """ Test that token info is used when headers are missing or incomplete, even if headers are present """
         class MockRequest:
@@ -353,7 +353,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         # user from headers will be overwritten by token_info if headers are incomplete
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-    
+
     def test_returns_none_when_no_auth_context(self):
         """Test that None is returned when KEYSTONE_AUTH_CONTEXT is missing"""
         class MockRequest:
@@ -361,51 +361,50 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'some-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'some-domain'
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertIsNone(user)
         self.assertIsNone(domain)
-    
 
 
 class TestHashTokenId(unittest.TestCase):
     """Test the hash_token_id function"""
-    
+
     def test_returns_consistent_hash(self):
         """Same input always produces the same output"""
         result1 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
         result2 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
-        
+
         self.assertEqual(result1, result2)
-    
+
     def test_different_tokens_produce_different_hashes(self):
         """Different token IDs produce different hashes"""
         result1 = lifesaver_logic.hash_token_id('token-1', 'secret-key')
         result2 = lifesaver_logic.hash_token_id('token-2', 'secret-key')
-        
+
         self.assertNotEqual(result1, result2)
-    
+
     def test_different_keys_produce_different_hashes(self):
         """Different secret keys produce different hashes"""
         result1 = lifesaver_logic.hash_token_id('test-token', 'key-1')
         result2 = lifesaver_logic.hash_token_id('test-token', 'key-2')
-        
+
         self.assertNotEqual(result1, result2)
-    
+
     def test_default_sha512_produces_128_char_hash(self):
         """SHA-512 (default) produces a 128-character hex digest"""
         result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
-        
+
         self.assertEqual(len(result), 128)
-    
+
     def test_sha256_produces_64_char_hash(self):
         """SHA-256 produces a 64-character hex digest"""
         result = lifesaver_logic.hash_token_id('test-token', 'secret-key', hash_function='sha256')
-        
+
         self.assertEqual(len(result), 64)
-    
+
     def test_falls_back_to_hostname_when_secret_key_is_none(self):
         """Falls back to hostname and returns a valid hash when secret key is None"""
         result = lifesaver_logic.hash_token_id('test-token', None)
@@ -431,11 +430,11 @@ class TestHashTokenId(unittest.TestCase):
         with self.assertLogs('lifesaver_logic', level=logging.WARNING) as cm:
             lifesaver_logic.hash_token_id('test-token', None)
         self.assertTrue(any('invalid_password_hash_secret_key' in line for line in cm.output))
-    
+
     def test_returns_hex_string(self):
         """Returns a valid hexadecimal string"""
         result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
-        
+
         # Should only contain hex characters
         self.assertTrue(all(c in '0123456789abcdef' for c in result))
 


### PR DESCRIPTION
This PR is the second of three that will provide the same logic as the bigger https://github.com/sapcc/keystone-extensions/pull/10

Token-based auth requests (`POST /v3/auth/tokens` with a token body, `GET /v3/auth/tokens` with `X-Subject-Token`) are now tracked separately from user/credential requests in the lifesaver rate limiter. Each token is HMAC-hashed before use as a memcache key (prefixed `FTOKENCREDS-`), preventing token leakage into cache storage.

Token costs differ from user costs by design: a `404` on token validation costs 10 (vs 0 for users) since a token-not-found response is a probing signal.

**Changes:**
- `lifesaver_logic.py`: `extract_token_id()` and `hash_token_id()` helpers; wired into `get_subject()`
- `lifesaver_utils.py`: `token_cost` config option with default `default:1,401:10,403:5,404:10,429:0`
- `lifesaver.py`: minor wiring update
- Unit tests for new extraction and hashing logic
