### PR TITLE
3/3 add E2E test suite and setup documentation for Lifesaver

### DIFF
--- a/cc/keystone/middleware/lifesaver.py
+++ b/cc/keystone/middleware/lifesaver.py
@@ -21,6 +21,7 @@ from . import lifesaver_logic as logic
 from . import lifesaver_utils as utils
 from . import response
 from .lifesaver_logic import calculate_cost
+from .lifesaver_logic import FTOKENCREDS_PREFIX
 from .lifesaver_logic import should_update_score_metadata
 from cc.keystone.middleware import score
 
@@ -50,11 +51,12 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
             self.logger.debug('refill-time is {0}'.format(self.utils.refill_time))
             self.logger.debug('refill-amount is {0}'.format(self.utils.refill_amount))
             self.logger.debug('status-costs are {0}'.format(self.utils.status_cost))
+            self.logger.debug('token-costs are {0}'.format(self.utils.token_cost))
 
     def get_subject(self, request):
         """
         Tries to fetch the rate-limit subject and its domain from the request.
-        The subject can be a user or credential identifier.
+        The subject can be a user, token, or credential identifier.
         :param request: the clients request
         :return: a dict with 'subject' and 'domain'
         """
@@ -70,6 +72,11 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
             subject, domain = logic.extract_password_auth_credentials(request)
             if not subject:
                 subject = logic.extract_app_credential(request)
+            if not subject:
+                token_id = logic.extract_token_id(request)
+                if token_id:
+                    token_hash = self.utils.hash_token_id(token_id)
+                    subject = FTOKENCREDS_PREFIX + token_hash
             if not subject:
                 subject, domain = logic.extract_s3_ec2_credentials(request)
             if not subject:
@@ -96,7 +103,7 @@ class LifesaverMiddleware(base.ConfigurableMiddleware):
             response.status_code,
             subject,
             self.utils.status_cost,
-            self.utils.status_cost
+            self.utils.token_cost
         )
 
         # deduct subject credit

--- a/cc/keystone/middleware/lifesaver_logic.py
+++ b/cc/keystone/middleware/lifesaver_logic.py
@@ -12,6 +12,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import hmac
+import logging
+import socket
+
+LOG = logging.getLogger(__name__)
+
+FTOKENCREDS_PREFIX = 'FTOKENCREDS-'
+
 
 def extract_password_auth_credentials(request):
     """
@@ -94,6 +102,34 @@ def extract_app_credential(request):
     return None
 
 
+def extract_token_id(request):
+    """
+    Extract token ID from request body or headers.
+
+    Args:
+        request: Request object
+    Returns:
+        str: Token ID or None if not found
+    """
+    # Check POST body for token
+    if request.path == '/v3/auth/tokens' and request.method == 'POST':
+        try:
+            body = request.json_body
+            if 'auth' in body and 'identity' in body['auth']:
+                if 'token' in body['auth']['identity']:
+                    return body['auth']['identity']['token'].get('id', None)
+        except Exception:
+            # Failed to parse JSON body
+            pass
+
+    # Check GET headers for token
+    if request.path == '/v3/auth/tokens' and request.method == 'GET':
+        if request.headers and 'X-Subject-Token' in request.headers:
+            return request.headers.get('X-Subject-Token', None)
+
+    return None
+
+
 def extract_s3_ec2_credentials(request):
     """
     Extract S3 or EC2 credentials from request body.
@@ -110,6 +146,7 @@ def extract_s3_ec2_credentials(request):
         try:
             body = request.json_body
         except Exception:
+            # Failed to parse JSON body
             return None, None
 
         # The order is taken from EC2_S3_Resource.py in keystone
@@ -166,24 +203,59 @@ def extract_from_authentication_request(request):
     return user, domain
 
 
+def hash_token_id(token_id: str, secret_key: str, hash_function: str = 'sha512') -> str:
+    """Hash a token ID using HMAC.
+
+    If secret_key is not set, the hostname is used as a fallback and a warning
+    is logged. Token rate-limiting remains active but the hash is less secure.
+
+    Args:
+        token_id: The token ID to hash.
+        secret_key: The secret key for HMAC.
+        hash_function: The hash algorithm to use (default: sha512).
+
+    Returns:
+        The hexadecimal digest of the HMAC hash.
+    """
+    if not secret_key:
+        LOG.warning(
+            "security_compliance.invalid_password_hash_secret_key is not set. "
+            "Token hashing will use the hostname as a fallback secret key. "
+            "This reduces security — please configure a proper secret key."
+        )
+        secret_key = socket.getfqdn()
+
+    return hmac.new(
+        key=secret_key.encode('utf-8'),
+        msg=token_id.encode('utf-8'),
+        digestmod=hash_function
+    ).hexdigest()
+
+
 def calculate_cost(status_code, user_identifier, status_cost_config, token_cost_config):
     """
     Calculate the cost for a request based on status code and user type.
 
     Args:
         status_code: HTTP status code (int)
-        user_identifier: User string
+        user_identifier: User string (used to determine if token-based)
         status_cost_config: Dict of status codes to costs for regular users
-        token_cost_config: Dict of status codes to costs for token users (unused in PR1)
+        token_cost_config: Dict of status codes to costs for token users
 
     Returns:
         int: Cost to deduct from user's credit
     """
+    # No cost for successful responses
     if status_code < 400:
         return 0
 
-    cost_table = status_cost_config
+    # Determine which cost table to use based on user prefix
+    if user_identifier.startswith(FTOKENCREDS_PREFIX):
+        cost_table = token_cost_config
+    else:
+        cost_table = status_cost_config
 
+    # Get cost for this status code, fallback to default
     status_str = str(status_code)
     if status_str in cost_table:
         return int(cost_table[status_str])

--- a/cc/keystone/middleware/lifesaver_utils.py
+++ b/cc/keystone/middleware/lifesaver_utils.py
@@ -19,6 +19,7 @@ import memcache
 from oslo_config import cfg
 
 from . import score
+from .lifesaver_logic import hash_token_id
 
 CONF = keystone.conf.CONF
 
@@ -50,6 +51,9 @@ class LifesaverUtils(object):
         CONF.register_opt(
             cfg.DictOpt('status_cost', default=conf.get('status_cost', "default:1,401:10,403:5,404:0,429:0"),
                         help='Credit consumption by status for users'), group=group)
+        CONF.register_opt(
+            cfg.DictOpt('token_cost', default=conf.get('token_cost', "default:1,401:10,403:5,404:10,429:0"),
+                        help='Credit consumption by status for tokens'), group=group)
 
         self.enabled = CONF.lifesaver.enabled.lower() in ['true', '1', 't', 'y', 'yes']
 
@@ -63,6 +67,7 @@ class LifesaverUtils(object):
         self.refill_time = CONF.lifesaver.refill_seconds
         self.refill_amount = CONF.lifesaver.refill_amount
         self.status_cost = CONF.lifesaver.status_cost
+        self.token_cost = CONF.lifesaver.token_cost
 
     def get_memcache_key(self, user: bytes | str):
         if isinstance(user, bytes):
@@ -83,3 +88,10 @@ class LifesaverUtils(object):
 
     def normalize(self, string=''):
         return string.strip().upper()
+
+    def hash_token_id(self, token_id: str) -> str:
+        return hash_token_id(
+            token_id,
+            secret_key=CONF.security_compliance.invalid_password_hash_secret_key,
+            hash_function=CONF.security_compliance.invalid_password_hash_function,
+        )

--- a/tests/E2E_TESTING_README.md
+++ b/tests/E2E_TESTING_README.md
@@ -25,104 +25,63 @@ of course you also need to create a virtual environment and install python depen
 
 this would be a correct output:
 ```
- Keystone is running at http://localhost:8000/v3
-Testing with user: admin@Default
-/Users/I761196/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none/lib/python3.10/unittest/suite.py:166: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61416), raddr=('127.0.0.1', 11211)>
-  setUpClass()
-ResourceWarning: Enable tracemalloc to get the object allocation traceback
+$ python -m unittest tests.test_lifesaver_e2e -v
 test_credit_refill_over_time (tests.test_lifesaver_e2e.TestLifesaverE2E)
-Test that credits refill over time allowing requests again ...
-======================================================================
-TEST: Credit refill over time
-======================================================================
-
-Phase 1: Exhausting credits for user test_refill_user_1767705102...
-[+] Rate limited after 3 attempts
-
-Phase 2: Waiting 70 seconds for credit refill...
-(This tests that credits are actually refilled over time)
-  70 seconds remaining...
-  60 seconds remaining...
-  50 seconds remaining...
-  40 seconds remaining...
-  30 seconds remaining...
-  20 seconds remaining...
-  10 seconds remaining...
-
-Phase 3: Testing if credits have been refilled...
-  Response status: 401
-[+] Credits refilled! Now getting 401 (auth failed) instead of 429
-This means rate limiting was lifted after credit refill
-ok
+Test that credits refill over time allowing requests again ... ok
 test_rate_limiting_across_auth_methods (tests.test_lifesaver_e2e.TestLifesaverE2E)
-Test that rate limiting works for all authentication methods ...
-======================================================================
-TEST: Rate limiting across different authentication methods
-======================================================================
-
-Preparing test data...
-  [Token Helper] Created and revoked token: gAAAAABpXQpVYL20mMds...
-  [Token Helper] Created revoked token: gAAAAABpXQpVbbsg0WPR...
-  [Token Helper] Created valid auth token: gAAAAABpXQpVMWpGYgiX...
-  [App Cred Helper] Using user_id: 786c5d9c6dfe4dd2a08d8156ffaa68e7
-  [App Cred Helper] Created app credential: ecf7a46aa4a94aef925a...
-  [App Cred Helper] Expires at: 2026-01-06T13:12:55Z
-  [App Cred Helper] Waiting 2 seconds for expiration...
-  [App Cred Helper] App credential should now be expired!
-
-Testing: password_auth_with_names
-  Endpoint: http://localhost:8000/v3/auth/tokens
-  Method: POST
-Rate limited after 3 attempts (Status: 429)
-Retry-After: 60 seconds
-
-Testing: password_auth_with_ids
-  Endpoint: http://localhost:8000/v3/auth/tokens
-  Method: POST
-Rate limited after 3 attempts (Status: 429)
-Retry-After: 60 seconds
-
-Testing: app_credential_auth
-  Endpoint: http://localhost:8000/v3/auth/tokens
-  Method: POST
-Rate limited after 3 attempts (Status: 429)
-Retry-After: 60 seconds
-
-Testing: token_auth_post_body
-  Endpoint: http://localhost:8000/v3/auth/tokens
-  Method: POST
-Rate limited after 3 attempts (Status: 429)
-Retry-After: 60 seconds
-
-Testing: token_auth_get_header
-  Endpoint: http://localhost:8000/v3/auth/tokens
-  Method: GET
-Rate limited after 1 attempts (Status: 429)
-Retry-After: 60 seconds
-
-Testing: s3_credentials
-  Endpoint: http://localhost:8000/v3/s3tokens
-  Method: POST
-Rate limited after 3 attempts (Status: 429)
-Retry-After: 60 seconds
-
-Testing: ec2_credentials
-  Endpoint: http://localhost:8000/v3/ec2tokens
-  Method: POST
-Rate limited after 3 attempts (Status: 429)
-Retry-After: 60 seconds
-ok
-test_environment_variables (tests.test_lifesaver_e2e.TestLifesaverE2ESetup)
-Check that required environment variables are accessible ...
-Using Keystone at: http://localhost:8000/v3
-ok
+Test that rate limiting works for all authentication methods. ... ok
 test_keystone_is_accessible (tests.test_lifesaver_e2e.TestLifesaverE2ESetup)
-Verify Keystone is running and accessible ... Keystone is accessible (status: 200)
-ok
+Verify Keystone is running and accessible ... ok
 
 ----------------------------------------------------------------------
-Ran 4 tests in 76.065s
+Ran 3 tests in 26.017s
 
 OK
+
+✓ Keystone is running at http://localhost:8000/v3
+Testing with user: admin@monsoon3
+
+============================================================
+TEST: Credit refill over time
+============================================================
+
+Phase 1: Exhausting credits for user test_refill_user_1778673567...
+Rate limited after 3 attempts
+
+Phase 2: Waiting 20 seconds for credit refill...
+20 seconds remaining...
+10 seconds remaining...
+
+Phase 3: Testing if credits have been refilled...
+Credits refilled! Now getting 401 instead of 429
+
+============================================================
+TEST: Rate limiting across different authentication methods
+============================================================
+
+Preparing test data...
+[App Cred Helper] Created app credential: dc8520bc8b35440cb426...
+
+Testing: password_auth
+Rate limited after 3 attempts
+
+Testing: token_auth_body
+Rate limited after 3 attempts
+
+Testing: token_auth_header
+Rate limited after 3 attempts
+
+Testing: app_credential
+Rate limited after 3 attempts
+
+Testing: s3_credentials
+Rate limited after 3 attempts
+
+Testing: ec2_credentials
+Rate limited after 3 attempts
+
+Using Keystone at: http://localhost:8000/v3
+Keystone is accessible (status: 200)
+
 
 ```

--- a/tests/E2E_TESTING_README.md
+++ b/tests/E2E_TESTING_README.md
@@ -1,0 +1,128 @@
+# Running End2End LifeSaver Tests
+
+In order to be able to run those tests you need to have a local keystone instance running on your machine. the following steps will describe how to set everything up.
+
+> Please follow the guide in the [Keystone repository](https://github.com/sapcc/keystone/blob/stable/2025.1-m3/LocalDeployment.md):
+
+When you are done with the guide, you need to replace the keystone extension
+dependency to point to the local repository you want to test.
+
+**point keystone-extensions to the local repository:**
+change **`custom-requirements.txt`**
+your branch could be different.
+```
+git+https://github.com/sapcc/keystone-extensions.git@stable/2025.1-m3#egg=keystone-extensions
+# to:
+-e /Path/to/keystone-extensions/
+```
+
+**running the E2E Tests:**
+while keystone local instance is running move to the **keystone-extensions** repository and execute:
+```
+python -m unittest tests.test_lifesaver_e2e -v 
+```
+of course you also need to create a virtual environment and install python dependencies before that.
+
+this would be a correct output:
+```
+ Keystone is running at http://localhost:8000/v3
+Testing with user: admin@Default
+/Users/I761196/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none/lib/python3.10/unittest/suite.py:166: ResourceWarning: unclosed <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 61416), raddr=('127.0.0.1', 11211)>
+  setUpClass()
+ResourceWarning: Enable tracemalloc to get the object allocation traceback
+test_credit_refill_over_time (tests.test_lifesaver_e2e.TestLifesaverE2E)
+Test that credits refill over time allowing requests again ...
+======================================================================
+TEST: Credit refill over time
+======================================================================
+
+Phase 1: Exhausting credits for user test_refill_user_1767705102...
+[+] Rate limited after 3 attempts
+
+Phase 2: Waiting 70 seconds for credit refill...
+(This tests that credits are actually refilled over time)
+  70 seconds remaining...
+  60 seconds remaining...
+  50 seconds remaining...
+  40 seconds remaining...
+  30 seconds remaining...
+  20 seconds remaining...
+  10 seconds remaining...
+
+Phase 3: Testing if credits have been refilled...
+  Response status: 401
+[+] Credits refilled! Now getting 401 (auth failed) instead of 429
+This means rate limiting was lifted after credit refill
+ok
+test_rate_limiting_across_auth_methods (tests.test_lifesaver_e2e.TestLifesaverE2E)
+Test that rate limiting works for all authentication methods ...
+======================================================================
+TEST: Rate limiting across different authentication methods
+======================================================================
+
+Preparing test data...
+  [Token Helper] Created and revoked token: gAAAAABpXQpVYL20mMds...
+  [Token Helper] Created revoked token: gAAAAABpXQpVbbsg0WPR...
+  [Token Helper] Created valid auth token: gAAAAABpXQpVMWpGYgiX...
+  [App Cred Helper] Using user_id: 786c5d9c6dfe4dd2a08d8156ffaa68e7
+  [App Cred Helper] Created app credential: ecf7a46aa4a94aef925a...
+  [App Cred Helper] Expires at: 2026-01-06T13:12:55Z
+  [App Cred Helper] Waiting 2 seconds for expiration...
+  [App Cred Helper] App credential should now be expired!
+
+Testing: password_auth_with_names
+  Endpoint: http://localhost:8000/v3/auth/tokens
+  Method: POST
+Rate limited after 3 attempts (Status: 429)
+Retry-After: 60 seconds
+
+Testing: password_auth_with_ids
+  Endpoint: http://localhost:8000/v3/auth/tokens
+  Method: POST
+Rate limited after 3 attempts (Status: 429)
+Retry-After: 60 seconds
+
+Testing: app_credential_auth
+  Endpoint: http://localhost:8000/v3/auth/tokens
+  Method: POST
+Rate limited after 3 attempts (Status: 429)
+Retry-After: 60 seconds
+
+Testing: token_auth_post_body
+  Endpoint: http://localhost:8000/v3/auth/tokens
+  Method: POST
+Rate limited after 3 attempts (Status: 429)
+Retry-After: 60 seconds
+
+Testing: token_auth_get_header
+  Endpoint: http://localhost:8000/v3/auth/tokens
+  Method: GET
+Rate limited after 1 attempts (Status: 429)
+Retry-After: 60 seconds
+
+Testing: s3_credentials
+  Endpoint: http://localhost:8000/v3/s3tokens
+  Method: POST
+Rate limited after 3 attempts (Status: 429)
+Retry-After: 60 seconds
+
+Testing: ec2_credentials
+  Endpoint: http://localhost:8000/v3/ec2tokens
+  Method: POST
+Rate limited after 3 attempts (Status: 429)
+Retry-After: 60 seconds
+ok
+test_environment_variables (tests.test_lifesaver_e2e.TestLifesaverE2ESetup)
+Check that required environment variables are accessible ...
+Using Keystone at: http://localhost:8000/v3
+ok
+test_keystone_is_accessible (tests.test_lifesaver_e2e.TestLifesaverE2ESetup)
+Verify Keystone is running and accessible ... Keystone is accessible (status: 200)
+ok
+
+----------------------------------------------------------------------
+Ran 4 tests in 76.065s
+
+OK
+
+```

--- a/tests/test_env_vars.sh
+++ b/tests/test_env_vars.sh
@@ -1,0 +1,7 @@
+export OS_AUTH_URL="http://localhost:8000/v3"
+export OS_IDENTITY_API_VERSION=3
+export OS_PASSWORD=s3cr3t
+export OS_PROJECT_DOMAIN_NAME=Default
+export OS_PROJECT_NAME=admin
+export OS_USERNAME=admin
+export OS_USER_DOMAIN_ID=default

--- a/tests/test_lifesaver_e2e.py
+++ b/tests/test_lifesaver_e2e.py
@@ -1,0 +1,413 @@
+"""
+End-to-End tests for Lifesaver middleware against a real Keystone instance.
+
+These tests require a running Keystone instance with the Lifesaver middleware enabled.
+Set environment variables to configure:
+- OS_AUTH_URL: Keystone endpoint (default: http://localhost:8000/v3)
+- OS_USERNAME: Admin username (default: admin)
+- OS_PASSWORD: Admin password (default: secret)
+- OS_USER_DOMAIN_NAME: Domain name (default: Default)
+- OS_PROJECT_NAME: Project name (default: admin)
+- OS_PROJECT_DOMAIN_NAME: Project domain (default: Default)
+
+Run with: python -m unittest tests.test_lifesaver_e2e -v
+
+Note: These tests will exhaust credits for test users, so run against a test instance only!
+"""
+
+import unittest
+import requests
+import os
+import time
+import memcache
+
+
+# Payloads
+
+def password_auth_payload(username, password, domain_id):
+    """Create a password authentication payload"""
+    return {
+        "auth": {
+            "identity": {
+                "methods": ["password"],
+                "password": {
+                    "user": {
+                        "name": username,
+                        "password": password,
+                        "domain": {"id": domain_id}
+                    }
+                }
+            }
+        }
+    }
+
+
+def token_auth_payload(token_id):
+    """Create a token authentication payload"""
+    return {
+        "auth": {
+            "identity": {
+                "methods": ["token"],
+                "token": {"id": token_id}
+            }
+        }
+    }
+
+
+def app_credential_payload(app_cred_id, app_cred_secret):
+    """Create an application credential authentication payload"""
+    return {
+        "auth": {
+            "identity": {
+                "methods": ["application_credential"],
+                "application_credential": {
+                    "id": app_cred_id,
+                    "secret": app_cred_secret
+                }
+            }
+        }
+    }
+
+
+def s3_credentials_payload(access_key, secret_key, token=""):
+    """Create an S3 credentials payload"""
+    return {
+        "credentials": {
+            "access": access_key,
+            "secret": secret_key,
+            "token": token
+        }
+    }
+
+
+def ec2_credentials_payload(access_key, secret_key, signature=""):
+    """Create an EC2 credentials payload"""
+    return {
+        "credentials": {
+            "access": access_key,
+            "secret": secret_key,
+            "signature": signature
+        }
+    }
+
+
+def scoped_password_auth_payload(username, password, user_domain_id, project_name, project_domain_id):
+    """Create a scoped password authentication payload"""
+    return {
+        "auth": {
+            "identity": {
+                "methods": ["password"],
+                "password": {
+                    "user": {
+                        "name": username,
+                        "password": password,
+                        "domain": {"id": user_domain_id}
+                    }
+                }
+            },
+            "scope": {
+                "project": {
+                    "name": project_name,
+                    "domain": {"id": project_domain_id}
+                }
+            }
+        }
+    }
+
+
+# Test Classes
+
+class TestLifesaverE2E(unittest.TestCase):
+    """End-to-end tests against real Keystone instance with Lifesaver middleware"""
+    
+    # Configuration constants
+    MAX_RATE_LIMIT_ATTEMPTS = 50
+    REFILL_WAIT_SECONDS = 20
+    
+    @classmethod
+    def setUpClass(cls):
+        """Set up test environment - check if Keystone is running"""
+        cls.auth_url = os.getenv('OS_AUTH_URL', 'http://localhost:8000/v3')
+        cls.admin_user = os.getenv('OS_USERNAME', 'admin')
+        cls.admin_password = os.getenv('OS_PASSWORD', 's3cr3t')
+        cls.domain = os.getenv('OS_USER_DOMAIN_NAME', 'Default')
+        cls.project = os.getenv('OS_PROJECT_NAME', 'admin')
+        cls.project_domain = os.getenv('OS_PROJECT_DOMAIN_NAME', 'Default')
+        cls.project_domain_id = os.getenv('OS_PROJECT_DOMAIN_ID', 'default')
+        cls.user_domain_id = os.getenv('OS_USER_DOMAIN_ID', 'default')
+        
+        # Set up memcache connection
+        cls.mc = memcache.Client(['127.0.0.1:11211'])
+        cls.mc.flush_all()
+        time.sleep(1)
+        
+        # Check if Keystone is running
+        cls._verify_keystone_available()
+        
+        print(f"\n✓ Keystone is running at {cls.auth_url}")
+        print(f"  Testing with user: {cls.admin_user}@{cls.domain}")
+    
+    @classmethod
+    def _verify_keystone_available(cls):
+        """Verify Keystone is running and accessible"""
+        try:
+            response = requests.get(cls.auth_url, timeout=5)
+            if response.status_code not in [200, 300]:
+                raise unittest.SkipTest(
+                    f"Keystone not responding correctly at {cls.auth_url}. "
+                    f"Got status {response.status_code}"
+                )
+        except requests.exceptions.RequestException as e:
+            raise unittest.SkipTest(f"Keystone not available at {cls.auth_url}. Error: {e}")
+    
+    def setUp(self):
+        """Set up each test"""
+        self.session = requests.Session()
+        # Disable SSL warnings for local testing
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    
+    def tearDown(self):
+        """Clean up after each test"""
+        self.session.close()
+    
+    # Helpers
+
+    def _make_request(self, method, endpoint, payload=None, headers=None):
+        """Make an HTTP request and return the response"""
+        if method == 'POST':
+            return self.session.post(endpoint, json=payload, headers=headers, verify=False)
+        elif method == 'GET':
+            return self.session.get(endpoint, headers=headers, verify=False)
+        elif method == 'DELETE':
+            return self.session.delete(endpoint, headers=headers, verify=False)
+        else:
+            raise ValueError(f"Unsupported method: {method}")
+    
+    def _get_admin_token(self):
+        """Get a valid admin token"""
+        payload = scoped_password_auth_payload(
+            self.admin_user, self.admin_password, self.user_domain_id,
+            self.project, self.project_domain_id
+        )
+        response = self._make_request('POST', f"{self.auth_url}/auth/tokens", payload)
+        
+        if response.status_code == 201:
+            return response.headers.get('X-Subject-Token')
+        return None
+    
+    def _get_admin_user_id(self):
+        """Get the admin user ID from token info"""
+        admin_token = self._get_admin_token()
+        if not admin_token:
+            return None
+        
+        response = self._make_request(
+            'GET',
+            f"{self.auth_url}/auth/tokens",
+            headers={'X-Auth-Token': admin_token, 'X-Subject-Token': admin_token}
+        )
+        
+        if response.status_code == 200:
+            return response.json().get('token', {}).get('user', {}).get('id')
+        return None
+    
+    def _create_app_credential(self):
+        """
+        Create a real application credential for testing.
+        
+        Returns:
+            tuple: (app_credential_id, app_credential_secret)
+        
+        Note: Use the real ID with a WRONG secret to trigger 401 errors
+        while still allowing the middleware to extract and track the credential ID.
+        """
+        admin_token = self._get_admin_token()
+        if not admin_token:
+            raise unittest.SkipTest("Could not get admin token for app credential creation")
+        
+        user_id = self._get_admin_user_id()
+        if not user_id:
+            raise unittest.SkipTest("Could not get admin user ID for app credential creation")
+        
+        payload = {
+            "application_credential": {
+                "name": f"test_ratelimit_{int(time.time())}",
+                "description": "Test app credential for rate limiting E2E test",
+                "roles": [{"name": "admin"}]
+            }
+        }
+        
+        response = self._make_request(
+            'POST',
+            f"{self.auth_url}/users/{user_id}/application_credentials",
+            payload,
+            headers={'X-Auth-Token': admin_token}
+        )
+        
+        if response.status_code == 201:
+            data = response.json()['application_credential']
+            print(f"  [App Cred Helper] Created app credential: {data['id'][:20]}...")
+            return data['id'], data['secret']
+        
+        raise unittest.SkipTest(f"Failed to create app credential: {response.text}")
+    
+    def _run_until_rate_limited(self, method, endpoint, payload=None, headers=None):
+        """
+        Send requests until rate limited (429) or max attempts reached.
+        Returns (rate_limited: bool, attempts: int)
+        """
+        for i in range(self.MAX_RATE_LIMIT_ATTEMPTS):
+            response = self._make_request(method, endpoint, payload, headers)
+            
+            if (i + 1) % 5 == 0:
+                print(f"    Attempt {i + 1}: Status {response.status_code}")
+            
+            if response.status_code == 429:
+                print(f"    Rate limited after {i + 1} attempts")
+                return True, i + 1
+        
+        return False, self.MAX_RATE_LIMIT_ATTEMPTS
+    
+    # Tests
+
+    def test_rate_limiting_across_auth_methods(self):
+        """
+        Test that rate limiting works for all authentication methods.
+        
+        Each scenario tests a DIFFERENT credential extraction path in the middleware:
+        - password_auth: Extracts username from password auth body
+        - token_auth_body: Extracts token ID from token auth body  
+        - token_auth_header: Extracts token ID from X-Subject-Token header
+        - app_credential: Extracts app credential ID from body
+        - s3_credentials: Extracts S3 access key from body
+        - ec2_credentials: Extracts EC2 access key from body
+        
+        We don't test different failure reasons (expired, revoked, invalid) separately
+        because the middleware treats all 4xx responses equally.
+        """
+        print("\n" + "=" * 60)
+        print("TEST: Rate limiting across different authentication methods")
+        print("=" * 60)
+        
+        valid_auth_token = self._get_admin_token()
+        if not valid_auth_token:
+            self.skipTest("Could not get admin token for header tests")
+        
+        print("\nPreparing test data...")
+        self._app_cred_id, _ = self._create_app_credential()
+        
+        scenarios = [
+            ("password_auth", "POST", f"{self.auth_url}/auth/tokens",
+             password_auth_payload("test_user", "wrong_password", self.user_domain_id), None),
+            
+            ("token_auth_body", "POST", f"{self.auth_url}/auth/tokens",
+             token_auth_payload("invalid-token-id"), None),
+            
+            ("token_auth_header", "GET", f"{self.auth_url}/auth/tokens",
+             None, {"X-Auth-Token": valid_auth_token, "X-Subject-Token": "invalid-token"}),
+            
+            ("app_credential", "POST", f"{self.auth_url}/auth/tokens",
+             app_credential_payload(self._app_cred_id, "wrong-secret-for-testing"), None),
+            
+            ("s3_credentials", "POST", f"{self.auth_url}/s3tokens",
+             s3_credentials_payload("fake_s3_access", "fake_s3_secret"), None),
+            
+            ("ec2_credentials", "POST", f"{self.auth_url}/ec2tokens",
+             ec2_credentials_payload("fake_ec2_access", "fake_ec2_secret", "fake_sig"), None),
+        ]
+        
+        # Test each scenario
+        for name, method, endpoint, payload, headers in scenarios:
+            with self.subTest(auth_method=name):
+                print(f"\nTesting: {name}")
+                
+                # Reset rate limit state
+                self.mc.flush_all()
+                time.sleep(0.5)
+                
+                rate_limited, attempts = self._run_until_rate_limited(method, endpoint, payload, headers)
+                
+                self.assertTrue(
+                    rate_limited,
+                    f"Rate limiting NOT triggered for {name} after {attempts} attempts"
+                )
+    
+    def test_credit_refill_over_time(self):
+        """Test that credits refill over time allowing requests again
+        You might need to check what is configured in keystone instance as
+        refill_seconds and adjust REFILL_WAIT_SECONDS accordingly.
+        """
+        print("\n" + "=" * 60)
+        print("TEST: Credit refill over time")
+        print("=" * 60)
+        
+        # Use unique user to avoid interference
+        test_user = f"test_refill_user_{int(time.time())}"
+        payload = password_auth_payload(test_user, "wrong_password", self.user_domain_id)
+        endpoint = f"{self.auth_url}/auth/tokens"
+        
+        # Phase 1: Exhaust credits
+        print(f"\nPhase 1: Exhausting credits for user {test_user}...")
+        rate_limited, _ = self._run_until_rate_limited('POST', endpoint, payload)
+        
+        if not rate_limited:
+            self.skipTest("Could not trigger rate limiting in phase 1")
+        
+        # Verify still rate limited
+        response = self._make_request('POST', endpoint, payload)
+        self.assertEqual(response.status_code, 429, "Should still be rate limited immediately after")
+        
+        # Phase 2: Wait for refill
+        print(f"\nPhase 2: Waiting {self.REFILL_WAIT_SECONDS} seconds for credit refill...")
+        for remaining in range(self.REFILL_WAIT_SECONDS, 0, -10):
+            print(f"  {remaining} seconds remaining...")
+            time.sleep(10)
+        
+        # Phase 3: Verify refill
+        print("\nPhase 3: Testing if credits have been refilled...")
+        response = self._make_request('POST', endpoint, payload)
+        status = response.status_code
+        
+        if status == 401:
+            print("  Credits refilled! Now getting 401 instead of 429")
+        elif status == 429:
+            self.skipTest(f"Still rate limited after {self.REFILL_WAIT_SECONDS}s - check refill_seconds config")
+        
+        self.assertNotEqual(status, 429, "Should not be rate limited after refill period")
+
+
+class TestLifesaverE2ESetup(unittest.TestCase):
+    """Tests to verify the E2E test environment is set up correctly"""
+    
+    def test_environment_variables(self):
+        """Check that required environment variables are accessible"""
+        auth_url = os.getenv('OS_AUTH_URL', 'http://localhost:8000/v3')
+        self.assertIsNotNone(auth_url, "OS_AUTH_URL should be set")
+        print(f"\n  Using Keystone at: {auth_url}")
+    
+    def test_keystone_is_accessible(self):
+        """Verify Keystone is running and accessible"""
+        auth_url = os.getenv('OS_AUTH_URL', 'http://localhost:8000/v3')
+        try:
+            response = requests.get(auth_url, timeout=5, verify=False)
+            self.assertIn(response.status_code, [200, 300],
+                         f"Keystone should respond with 200/300, got {response.status_code}")
+            print(f"  Keystone is accessible (status: {response.status_code})")
+        except requests.exceptions.RequestException as e:
+            self.fail(f"Cannot connect to Keystone at {auth_url}: {e}")
+
+
+if __name__ == '__main__':
+    print("\n" + "=" * 60)
+    print("Lifesaver Middleware - End-to-End Tests")
+    print("=" * 60)
+    print("\nThese tests run against a REAL Keystone instance.")
+    print("Make sure you're running against a TEST instance!")
+    print("\nEnvironment:")
+    print(f"  OS_AUTH_URL: {os.getenv('OS_AUTH_URL', 'http://localhost:8000/v3')}")
+    print(f"  OS_USERNAME: {os.getenv('OS_USERNAME', 'admin')}")
+    print(f"  OS_USER_DOMAIN_NAME: {os.getenv('OS_USER_DOMAIN_NAME', 'Default')}")
+    print("=" * 60 + "\n")
+    
+    unittest.main(verbosity=2)

--- a/tests/test_lifesaver_e2e.py
+++ b/tests/test_lifesaver_e2e.py
@@ -1,3 +1,17 @@
+# Copyright 2026 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
 """
 End-to-End tests for Lifesaver middleware against a real Keystone instance.
 
@@ -5,7 +19,7 @@ These tests require a running Keystone instance with the Lifesaver middleware en
 Set environment variables to configure:
 - OS_AUTH_URL: Keystone endpoint (default: http://localhost:8000/v3)
 - OS_USERNAME: Admin username (default: admin)
-- OS_PASSWORD: Admin password (default: secret)
+- OS_PASSWORD: Admin password (default: s3cr3t)
 - OS_USER_DOMAIN_NAME: Domain name (default: Default)
 - OS_PROJECT_NAME: Project name (default: admin)
 - OS_PROJECT_DOMAIN_NAME: Project domain (default: Default)
@@ -380,15 +394,12 @@ class TestLifesaverE2E(unittest.TestCase):
 class TestLifesaverE2ESetup(unittest.TestCase):
     """Tests to verify the E2E test environment is set up correctly"""
     
-    def test_environment_variables(self):
-        """Check that required environment variables are accessible"""
-        auth_url = os.getenv('OS_AUTH_URL', 'http://localhost:8000/v3')
-        self.assertIsNotNone(auth_url, "OS_AUTH_URL should be set")
-        print(f"\n  Using Keystone at: {auth_url}")
-    
     def test_keystone_is_accessible(self):
         """Verify Keystone is running and accessible"""
-        auth_url = os.getenv('OS_AUTH_URL', 'http://localhost:8000/v3')
+        auth_url = os.getenv('OS_AUTH_URL')
+        self.assertIsNotNone(auth_url, "OS_AUTH_URL should be set")
+        print(f"\n  Using Keystone at: {auth_url}")
+
         try:
             response = requests.get(auth_url, timeout=5, verify=False)
             self.assertIn(response.status_code, [200, 300],
@@ -405,7 +416,7 @@ if __name__ == '__main__':
     print("\nThese tests run against a REAL Keystone instance.")
     print("Make sure you're running against a TEST instance!")
     print("\nEnvironment:")
-    print(f"  OS_AUTH_URL: {os.getenv('OS_AUTH_URL', 'http://localhost:8000/v3')}")
+    print(f"  OS_AUTH_URL: {os.getenv('OS_AUTH_URL')}")
     print(f"  OS_USERNAME: {os.getenv('OS_USERNAME', 'admin')}")
     print(f"  OS_USER_DOMAIN_NAME: {os.getenv('OS_USER_DOMAIN_NAME', 'Default')}")
     print("=" * 60 + "\n")

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -33,7 +33,7 @@ spec.loader.exec_module(lifesaver_logic)
 
 class TestExtractPasswordAuthCredentials(unittest.TestCase):
     """Test extracting credentials from password authentication"""
-    
+
     def test_extracts_user_and_domain_by_name(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -50,13 +50,13 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-        
+
         self.assertEqual(user, "testuser")
         self.assertEqual(domain, "TestDomain")
-    
+
     def test_extracts_user_and_domain_by_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -73,17 +73,17 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-        
+
         self.assertEqual(user, "id-user-123")
         self.assertEqual(domain, "domain-456")
 
 
 class TestExtractAppCredential(unittest.TestCase):
     """Test extracting application credentials"""
-    
+
     def test_extracts_app_credential_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -140,41 +140,41 @@ class TestExtractTokenId(unittest.TestCase):
 
 class TestExtractS3Ec2Credentials(unittest.TestCase):
     """Test extracting S3/EC2 credentials"""
-    
+
     def test_extracts_s3_credentials(self):
         class MockRequest:
             path = '/v3/s3tokens'
             method = 'POST'
             json_body = {"credentials": {"access": "s3-access-key-123"}}
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-        
+
         self.assertEqual(user, "s3creds-s3-access-key-123")
         self.assertEqual(domain, "unknown")
-    
+
     def test_extracts_ec2_credentials(self):
         class MockRequest:
             path = '/v3/ec2tokens'
             method = 'POST'
             json_body = {"ec2Credentials": {"access": "ec2-access-key-456"}}
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-        
+
         self.assertEqual(user, "ec2creds-ec2-access-key-456")
         self.assertEqual(domain, "unknown")
 
 
 class TestCalculateCost(unittest.TestCase):
     """Test cost calculation logic"""
-    
+
     def test_no_cost_for_2xx_status(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 10}
-        
+
         cost = lifesaver_logic.calculate_cost(200, 'SOME-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 0)
 
     def test_404_for_token_user_uses_token_cost(self):
@@ -204,67 +204,67 @@ class TestCalculateCost(unittest.TestCase):
     def test_unknown_status_uses_default(self):
         status_cost = {'default': 5}
         token_cost = {'default': 3}
-        
+
         cost = lifesaver_logic.calculate_cost(418, 'PASSWORD-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 5)
 
 
 class TestShouldUpdateScoreMetadata(unittest.TestCase):
     """Test score metadata update detection"""
-    
+
     def test_returns_true_when_credit_changed(self):
         class MockScore:
             credit = 50
             refill_time = 60
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_true_when_refill_time_changed(self):
         class MockScore:
             credit = 100
             refill_time = 30
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_true_when_refill_amount_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 3
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_false_when_nothing_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertFalse(result)
 
 
 class TestExtractFromAuthenticationRequest(unittest.TestCase):
     """Test extracting user from authenticated request"""
-    
+
     def test_extracts_user_from_request_headers(self):
         """Test extracting user and domain from HTTP headers"""
         class MockRequest:
@@ -273,13 +273,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'header-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'header-domain'
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-    
+
     def test_extracts_user_from_token_info(self):
         """Test extracting user and domain from token info when headers not present"""
         class MockRequest:
@@ -296,13 +296,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-    
+
     def test_prefers_headers_over_token_info(self):
         """Test that headers take precedence over token info"""
         class MockRequest:
@@ -321,13 +321,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-    
+
     def test_falls_back_to_token_info_when_headers_incomplete(self):
         """ Test that token info is used when headers are missing or incomplete, even if headers are present """
         class MockRequest:
@@ -353,7 +353,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         # user from headers will be overwritten by token_info if headers are incomplete
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-    
+
     def test_returns_none_when_no_auth_context(self):
         """Test that None is returned when KEYSTONE_AUTH_CONTEXT is missing"""
         class MockRequest:
@@ -361,10 +361,10 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'some-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'some-domain'
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertIsNone(user)
         self.assertIsNone(domain)
 

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -19,11 +19,11 @@ import importlib.util
 # Load the module directly from file path, bypassing forced
 # package imports that would cause a need for unnecessary mocking.
 module_path = os.path.join(
-    os.path.dirname(__file__),
-    '..',
-    'cc',
-    'keystone',
-    'middleware',
+    os.path.dirname(__file__), 
+    '..', 
+    'cc', 
+    'keystone', 
+    'middleware', 
     'lifesaver_logic.py'
 )
 spec = importlib.util.spec_from_file_location("lifesaver_logic", module_path)
@@ -33,7 +33,7 @@ spec.loader.exec_module(lifesaver_logic)
 
 class TestExtractPasswordAuthCredentials(unittest.TestCase):
     """Test extracting credentials from password authentication"""
-
+    
     def test_extracts_user_and_domain_by_name(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -50,13 +50,13 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-
+        
         self.assertEqual(user, "testuser")
         self.assertEqual(domain, "TestDomain")
-
+    
     def test_extracts_user_and_domain_by_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -73,17 +73,17 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-
+        
         self.assertEqual(user, "id-user-123")
         self.assertEqual(domain, "domain-456")
 
 
 class TestExtractAppCredential(unittest.TestCase):
     """Test extracting application credentials"""
-
+    
     def test_extracts_app_credential_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -102,127 +102,169 @@ class TestExtractAppCredential(unittest.TestCase):
         result = lifesaver_logic.extract_app_credential(request)
 
         self.assertEqual(result, "ac-app-cred-789")
+    
+
+class TestExtractTokenId(unittest.TestCase):
+    """Test extracting token IDs from requests"""
+    
+    def test_extracts_token_from_post_body(self):
+        class MockRequest:
+            path = '/v3/auth/tokens'
+            method = 'POST'
+            json_body = {
+                "auth": {
+                    "identity": {
+                        "token": {"id": "test-token-abc"}
+                    }
+                }
+            }
+            headers = {}
+        
+        request = MockRequest()
+        result = lifesaver_logic.extract_token_id(request)
+        
+        self.assertEqual(result, "test-token-abc")
+    
+    def test_extracts_token_from_get_headers(self):
+        class MockRequest:
+            path = '/v3/auth/tokens'
+            method = 'GET'
+            json_body = {}
+            headers = {'X-Subject-Token': 'header-token-xyz'}
+        
+        request = MockRequest()
+        result = lifesaver_logic.extract_token_id(request)
+        
+        self.assertEqual(result, "header-token-xyz")
 
 
 class TestExtractS3Ec2Credentials(unittest.TestCase):
     """Test extracting S3/EC2 credentials"""
-
+    
     def test_extracts_s3_credentials(self):
         class MockRequest:
             path = '/v3/s3tokens'
             method = 'POST'
             json_body = {"credentials": {"access": "s3-access-key-123"}}
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-
+        
         self.assertEqual(user, "s3creds-s3-access-key-123")
         self.assertEqual(domain, "unknown")
-
+    
     def test_extracts_ec2_credentials(self):
         class MockRequest:
             path = '/v3/ec2tokens'
             method = 'POST'
             json_body = {"ec2Credentials": {"access": "ec2-access-key-456"}}
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-
+        
         self.assertEqual(user, "ec2creds-ec2-access-key-456")
         self.assertEqual(domain, "unknown")
 
 
 class TestCalculateCost(unittest.TestCase):
     """Test cost calculation logic"""
-
+    
     def test_no_cost_for_2xx_status(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 10}
-
+        
         cost = lifesaver_logic.calculate_cost(200, 'SOME-USER', status_cost, token_cost)
-
+        
         self.assertEqual(cost, 0)
-
-    def test_default_cost_applied_for_404(self):
-        status_cost = {'default': 1, '401': 10}
-        token_cost = {'default': 1, '401': 10}
-
+    
+    def test_404_for_token_user_uses_token_cost(self):
+        status_cost = {'default': 1, '404': 0}
+        token_cost = {'default': 1, '404': 10}
+        
+        cost = lifesaver_logic.calculate_cost(404, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER-123', status_cost, token_cost)
+        
+        self.assertEqual(cost, 10)
+    
+    def test_404_for_password_user_uses_status_cost(self):
+        status_cost = {'default': 1, '404': 0}
+        token_cost = {'default': 1, '404': 10}
+        
         cost = lifesaver_logic.calculate_cost(404, 'PASSWORD-USER', status_cost, token_cost)
-
-        self.assertEqual(cost, 1)
-
-    def test_401_uses_status_cost(self):
+        
+        self.assertEqual(cost, 0)
+    
+    def test_401_for_token_user(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 15}
-
-        cost = lifesaver_logic.calculate_cost(401, 'PASSWORD-USER', status_cost, token_cost)
-
-        self.assertEqual(cost, 10)
-
+        
+        cost = lifesaver_logic.calculate_cost(401, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER', status_cost, token_cost)
+        
+        self.assertEqual(cost, 15)
+    
     def test_unknown_status_uses_default(self):
         status_cost = {'default': 5}
         token_cost = {'default': 3}
-
+        
         cost = lifesaver_logic.calculate_cost(418, 'PASSWORD-USER', status_cost, token_cost)
-
+        
         self.assertEqual(cost, 5)
 
 
 class TestShouldUpdateScoreMetadata(unittest.TestCase):
     """Test score metadata update detection"""
-
+    
     def test_returns_true_when_credit_changed(self):
         class MockScore:
             credit = 50
             refill_time = 60
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_true_when_refill_time_changed(self):
         class MockScore:
             credit = 100
             refill_time = 30
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_true_when_refill_amount_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 3
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_false_when_nothing_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertFalse(result)
 
 
 class TestExtractFromAuthenticationRequest(unittest.TestCase):
     """Test extracting user from authenticated request"""
-
+    
     def test_extracts_user_from_request_headers(self):
         """Test extracting user and domain from HTTP headers"""
         class MockRequest:
@@ -231,13 +273,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'header-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'header-domain'
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-
+    
     def test_extracts_user_from_token_info(self):
         """Test extracting user and domain from token info when headers not present"""
         class MockRequest:
@@ -254,13 +296,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-
+    
     def test_prefers_headers_over_token_info(self):
         """Test that headers take precedence over token info"""
         class MockRequest:
@@ -279,13 +321,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-
+    
     def test_falls_back_to_token_info_when_headers_incomplete(self):
         """ Test that token info is used when headers are missing or incomplete, even if headers are present """
         class MockRequest:
@@ -311,7 +353,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         # user from headers will be overwritten by token_info if headers are incomplete
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-
+    
     def test_returns_none_when_no_auth_context(self):
         """Test that None is returned when KEYSTONE_AUTH_CONTEXT is missing"""
         class MockRequest:
@@ -319,12 +361,83 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'some-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'some-domain'
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertIsNone(user)
         self.assertIsNone(domain)
+    
+
+
+class TestHashTokenId(unittest.TestCase):
+    """Test the hash_token_id function"""
+    
+    def test_returns_consistent_hash(self):
+        """Same input always produces the same output"""
+        result1 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        result2 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        
+        self.assertEqual(result1, result2)
+    
+    def test_different_tokens_produce_different_hashes(self):
+        """Different token IDs produce different hashes"""
+        result1 = lifesaver_logic.hash_token_id('token-1', 'secret-key')
+        result2 = lifesaver_logic.hash_token_id('token-2', 'secret-key')
+        
+        self.assertNotEqual(result1, result2)
+    
+    def test_different_keys_produce_different_hashes(self):
+        """Different secret keys produce different hashes"""
+        result1 = lifesaver_logic.hash_token_id('test-token', 'key-1')
+        result2 = lifesaver_logic.hash_token_id('test-token', 'key-2')
+        
+        self.assertNotEqual(result1, result2)
+    
+    def test_default_sha512_produces_128_char_hash(self):
+        """SHA-512 (default) produces a 128-character hex digest"""
+        result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        
+        self.assertEqual(len(result), 128)
+    
+    def test_sha256_produces_64_char_hash(self):
+        """SHA-256 produces a 64-character hex digest"""
+        result = lifesaver_logic.hash_token_id('test-token', 'secret-key', hash_function='sha256')
+        
+        self.assertEqual(len(result), 64)
+    
+    def test_falls_back_to_hostname_when_secret_key_is_none(self):
+        """Falls back to hostname and returns a valid hash when secret key is None"""
+        result = lifesaver_logic.hash_token_id('test-token', None)
+        self.assertTrue(all(c in '0123456789abcdef' for c in result))
+
+    def test_falls_back_to_hostname_when_secret_key_is_empty(self):
+        """Falls back to hostname and returns a valid hash when secret key is empty"""
+        result = lifesaver_logic.hash_token_id('test-token', '')
+        self.assertTrue(all(c in '0123456789abcdef' for c in result))
+
+    def test_fallback_matches_explicit_hostname_key(self):
+        """Hash with missing key equals hash using hostname as key"""
+        import socket
+        result_fallback = lifesaver_logic.hash_token_id('test-token', None)
+        result_hostname = lifesaver_logic.hash_token_id('test-token', socket.getfqdn())
+        self.assertIsNotNone(result_fallback)
+        self.assertNotEqual(result_fallback, '')
+        self.assertEqual(result_fallback, result_hostname)
+
+    def test_logs_warning_when_secret_key_is_missing(self):
+        """Warning is logged when secret key is None or empty"""
+        import logging
+        with self.assertLogs('lifesaver_logic', level=logging.WARNING) as cm:
+            lifesaver_logic.hash_token_id('test-token', None)
+        self.assertTrue(any('invalid_password_hash_secret_key' in line for line in cm.output))
+    
+    def test_returns_hex_string(self):
+        """Returns a valid hexadecimal string"""
+        result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
+        
+        # Should only contain hex characters
+        self.assertTrue(all(c in '0123456789abcdef' for c in result))
 
 
 if __name__ == '__main__':

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -33,7 +33,7 @@ spec.loader.exec_module(lifesaver_logic)
 
 class TestExtractPasswordAuthCredentials(unittest.TestCase):
     """Test extracting credentials from password authentication"""
-
+    
     def test_extracts_user_and_domain_by_name(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -50,13 +50,13 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-
+        
         self.assertEqual(user, "testuser")
         self.assertEqual(domain, "TestDomain")
-
+    
     def test_extracts_user_and_domain_by_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -73,17 +73,17 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-
+        
         self.assertEqual(user, "id-user-123")
         self.assertEqual(domain, "domain-456")
 
 
 class TestExtractAppCredential(unittest.TestCase):
     """Test extracting application credentials"""
-
+    
     def test_extracts_app_credential_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -140,41 +140,41 @@ class TestExtractTokenId(unittest.TestCase):
 
 class TestExtractS3Ec2Credentials(unittest.TestCase):
     """Test extracting S3/EC2 credentials"""
-
+    
     def test_extracts_s3_credentials(self):
         class MockRequest:
             path = '/v3/s3tokens'
             method = 'POST'
             json_body = {"credentials": {"access": "s3-access-key-123"}}
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-
+        
         self.assertEqual(user, "s3creds-s3-access-key-123")
         self.assertEqual(domain, "unknown")
-
+    
     def test_extracts_ec2_credentials(self):
         class MockRequest:
             path = '/v3/ec2tokens'
             method = 'POST'
             json_body = {"ec2Credentials": {"access": "ec2-access-key-456"}}
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-
+        
         self.assertEqual(user, "ec2creds-ec2-access-key-456")
         self.assertEqual(domain, "unknown")
 
 
 class TestCalculateCost(unittest.TestCase):
     """Test cost calculation logic"""
-
+    
     def test_no_cost_for_2xx_status(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 10}
-
+        
         cost = lifesaver_logic.calculate_cost(200, 'SOME-USER', status_cost, token_cost)
-
+        
         self.assertEqual(cost, 0)
 
     def test_404_for_token_user_uses_token_cost(self):
@@ -204,67 +204,67 @@ class TestCalculateCost(unittest.TestCase):
     def test_unknown_status_uses_default(self):
         status_cost = {'default': 5}
         token_cost = {'default': 3}
-
+        
         cost = lifesaver_logic.calculate_cost(418, 'PASSWORD-USER', status_cost, token_cost)
-
+        
         self.assertEqual(cost, 5)
 
 
 class TestShouldUpdateScoreMetadata(unittest.TestCase):
     """Test score metadata update detection"""
-
+    
     def test_returns_true_when_credit_changed(self):
         class MockScore:
             credit = 50
             refill_time = 60
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_true_when_refill_time_changed(self):
         class MockScore:
             credit = 100
             refill_time = 30
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_true_when_refill_amount_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 3
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertTrue(result)
-
+    
     def test_returns_false_when_nothing_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 5
-
+        
         score = MockScore()
-
+        
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-
+        
         self.assertFalse(result)
 
 
 class TestExtractFromAuthenticationRequest(unittest.TestCase):
     """Test extracting user from authenticated request"""
-
+    
     def test_extracts_user_from_request_headers(self):
         """Test extracting user and domain from HTTP headers"""
         class MockRequest:
@@ -273,13 +273,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'header-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'header-domain'
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-
+    
     def test_extracts_user_from_token_info(self):
         """Test extracting user and domain from token info when headers not present"""
         class MockRequest:
@@ -296,13 +296,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-
+    
     def test_prefers_headers_over_token_info(self):
         """Test that headers take precedence over token info"""
         class MockRequest:
@@ -321,13 +321,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-
+    
     def test_falls_back_to_token_info_when_headers_incomplete(self):
         """ Test that token info is used when headers are missing or incomplete, even if headers are present """
         class MockRequest:
@@ -353,7 +353,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         # user from headers will be overwritten by token_info if headers are incomplete
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-
+    
     def test_returns_none_when_no_auth_context(self):
         """Test that None is returned when KEYSTONE_AUTH_CONTEXT is missing"""
         class MockRequest:
@@ -361,10 +361,10 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'some-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'some-domain'
             }
-
+        
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-
+        
         self.assertIsNone(user)
         self.assertIsNone(domain)
 

--- a/tests/test_lifesaver_logic.py
+++ b/tests/test_lifesaver_logic.py
@@ -20,10 +20,10 @@ import importlib.util
 # package imports that would cause a need for unnecessary mocking.
 module_path = os.path.join(
     os.path.dirname(__file__), 
-    '..', 
-    'cc', 
-    'keystone', 
-    'middleware', 
+    '..',
+    'cc',
+    'keystone',
+    'middleware',
     'lifesaver_logic.py'
 )
 spec = importlib.util.spec_from_file_location("lifesaver_logic", module_path)
@@ -33,7 +33,7 @@ spec.loader.exec_module(lifesaver_logic)
 
 class TestExtractPasswordAuthCredentials(unittest.TestCase):
     """Test extracting credentials from password authentication"""
-    
+
     def test_extracts_user_and_domain_by_name(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -50,13 +50,13 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-        
+
         self.assertEqual(user, "testuser")
         self.assertEqual(domain, "TestDomain")
-    
+
     def test_extracts_user_and_domain_by_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -73,17 +73,17 @@ class TestExtractPasswordAuthCredentials(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_password_auth_credentials(request)
-        
+
         self.assertEqual(user, "id-user-123")
         self.assertEqual(domain, "domain-456")
 
 
 class TestExtractAppCredential(unittest.TestCase):
     """Test extracting application credentials"""
-    
+
     def test_extracts_app_credential_id(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -102,11 +102,11 @@ class TestExtractAppCredential(unittest.TestCase):
         result = lifesaver_logic.extract_app_credential(request)
 
         self.assertEqual(result, "ac-app-cred-789")
-    
+
 
 class TestExtractTokenId(unittest.TestCase):
     """Test extracting token IDs from requests"""
-    
+
     def test_extracts_token_from_post_body(self):
         class MockRequest:
             path = '/v3/auth/tokens'
@@ -119,152 +119,152 @@ class TestExtractTokenId(unittest.TestCase):
                 }
             }
             headers = {}
-        
+
         request = MockRequest()
         result = lifesaver_logic.extract_token_id(request)
-        
+
         self.assertEqual(result, "test-token-abc")
-    
+
     def test_extracts_token_from_get_headers(self):
         class MockRequest:
             path = '/v3/auth/tokens'
             method = 'GET'
             json_body = {}
             headers = {'X-Subject-Token': 'header-token-xyz'}
-        
+
         request = MockRequest()
         result = lifesaver_logic.extract_token_id(request)
-        
+
         self.assertEqual(result, "header-token-xyz")
 
 
 class TestExtractS3Ec2Credentials(unittest.TestCase):
     """Test extracting S3/EC2 credentials"""
-    
+
     def test_extracts_s3_credentials(self):
         class MockRequest:
             path = '/v3/s3tokens'
             method = 'POST'
             json_body = {"credentials": {"access": "s3-access-key-123"}}
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-        
+
         self.assertEqual(user, "s3creds-s3-access-key-123")
         self.assertEqual(domain, "unknown")
-    
+
     def test_extracts_ec2_credentials(self):
         class MockRequest:
             path = '/v3/ec2tokens'
             method = 'POST'
             json_body = {"ec2Credentials": {"access": "ec2-access-key-456"}}
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_s3_ec2_credentials(request)
-        
+
         self.assertEqual(user, "ec2creds-ec2-access-key-456")
         self.assertEqual(domain, "unknown")
 
 
 class TestCalculateCost(unittest.TestCase):
     """Test cost calculation logic"""
-    
+
     def test_no_cost_for_2xx_status(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 10}
-        
+
         cost = lifesaver_logic.calculate_cost(200, 'SOME-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 0)
-    
+
     def test_404_for_token_user_uses_token_cost(self):
         status_cost = {'default': 1, '404': 0}
         token_cost = {'default': 1, '404': 10}
-        
+
         cost = lifesaver_logic.calculate_cost(404, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER-123', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 10)
-    
+
     def test_404_for_password_user_uses_status_cost(self):
         status_cost = {'default': 1, '404': 0}
         token_cost = {'default': 1, '404': 10}
-        
+
         cost = lifesaver_logic.calculate_cost(404, 'PASSWORD-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 0)
-    
+
     def test_401_for_token_user(self):
         status_cost = {'default': 1, '401': 10}
         token_cost = {'default': 1, '401': 15}
-        
+
         cost = lifesaver_logic.calculate_cost(401, lifesaver_logic.FTOKENCREDS_PREFIX + 'USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 15)
-    
+
     def test_unknown_status_uses_default(self):
         status_cost = {'default': 5}
         token_cost = {'default': 3}
-        
+
         cost = lifesaver_logic.calculate_cost(418, 'PASSWORD-USER', status_cost, token_cost)
-        
+
         self.assertEqual(cost, 5)
 
 
 class TestShouldUpdateScoreMetadata(unittest.TestCase):
     """Test score metadata update detection"""
-    
+
     def test_returns_true_when_credit_changed(self):
         class MockScore:
             credit = 50
             refill_time = 60
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_true_when_refill_time_changed(self):
         class MockScore:
             credit = 100
             refill_time = 30
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_true_when_refill_amount_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 3
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertTrue(result)
-    
+
     def test_returns_false_when_nothing_changed(self):
         class MockScore:
             credit = 100
             refill_time = 60
             refill_amount = 5
-        
+
         score = MockScore()
-        
+
         result = lifesaver_logic.should_update_score_metadata(score, 100, 60, 5)
-        
+
         self.assertFalse(result)
 
 
 class TestExtractFromAuthenticationRequest(unittest.TestCase):
     """Test extracting user from authenticated request"""
-    
+
     def test_extracts_user_from_request_headers(self):
         """Test extracting user and domain from HTTP headers"""
         class MockRequest:
@@ -273,13 +273,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'header-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'header-domain'
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-    
+
     def test_extracts_user_from_token_info(self):
         """Test extracting user and domain from token info when headers not present"""
         class MockRequest:
@@ -296,13 +296,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-    
+
     def test_prefers_headers_over_token_info(self):
         """Test that headers take precedence over token info"""
         class MockRequest:
@@ -321,13 +321,13 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                     }
                 }
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertEqual(user, 'header-user')
         self.assertEqual(domain, 'header-domain')
-    
+
     def test_falls_back_to_token_info_when_headers_incomplete(self):
         """ Test that token info is used when headers are missing or incomplete, even if headers are present """
         class MockRequest:
@@ -353,7 +353,7 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
         # user from headers will be overwritten by token_info if headers are incomplete
         self.assertEqual(user, 'token-user')
         self.assertEqual(domain, 'token-domain')
-    
+
     def test_returns_none_when_no_auth_context(self):
         """Test that None is returned when KEYSTONE_AUTH_CONTEXT is missing"""
         class MockRequest:
@@ -361,51 +361,50 @@ class TestExtractFromAuthenticationRequest(unittest.TestCase):
                 'HTTP_X_USER_NAME': 'some-user',
                 'HTTP_X_USER_DOMAIN_NAME': 'some-domain'
             }
-        
+
         request = MockRequest()
         user, domain = lifesaver_logic.extract_from_authentication_request(request)
-        
+
         self.assertIsNone(user)
         self.assertIsNone(domain)
-    
 
 
 class TestHashTokenId(unittest.TestCase):
     """Test the hash_token_id function"""
-    
+
     def test_returns_consistent_hash(self):
         """Same input always produces the same output"""
         result1 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
         result2 = lifesaver_logic.hash_token_id('test-token', 'secret-key')
-        
+
         self.assertEqual(result1, result2)
-    
+
     def test_different_tokens_produce_different_hashes(self):
         """Different token IDs produce different hashes"""
         result1 = lifesaver_logic.hash_token_id('token-1', 'secret-key')
         result2 = lifesaver_logic.hash_token_id('token-2', 'secret-key')
-        
+
         self.assertNotEqual(result1, result2)
-    
+
     def test_different_keys_produce_different_hashes(self):
         """Different secret keys produce different hashes"""
         result1 = lifesaver_logic.hash_token_id('test-token', 'key-1')
         result2 = lifesaver_logic.hash_token_id('test-token', 'key-2')
-        
+
         self.assertNotEqual(result1, result2)
-    
+
     def test_default_sha512_produces_128_char_hash(self):
         """SHA-512 (default) produces a 128-character hex digest"""
         result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
-        
+
         self.assertEqual(len(result), 128)
-    
+
     def test_sha256_produces_64_char_hash(self):
         """SHA-256 produces a 64-character hex digest"""
         result = lifesaver_logic.hash_token_id('test-token', 'secret-key', hash_function='sha256')
-        
+
         self.assertEqual(len(result), 64)
-    
+
     def test_falls_back_to_hostname_when_secret_key_is_none(self):
         """Falls back to hostname and returns a valid hash when secret key is None"""
         result = lifesaver_logic.hash_token_id('test-token', None)
@@ -431,11 +430,11 @@ class TestHashTokenId(unittest.TestCase):
         with self.assertLogs('lifesaver_logic', level=logging.WARNING) as cm:
             lifesaver_logic.hash_token_id('test-token', None)
         self.assertTrue(any('invalid_password_hash_secret_key' in line for line in cm.output))
-    
+
     def test_returns_hex_string(self):
         """Returns a valid hexadecimal string"""
         result = lifesaver_logic.hash_token_id('test-token', 'secret-key')
-        
+
         # Should only contain hex characters
         self.assertTrue(all(c in '0123456789abcdef' for c in result))
 


### PR DESCRIPTION
This PR is the third of three that will provide the same logic as the bigger https://github.com/sapcc/keystone-extensions/pull/10

- Add test_lifesaver_e2e.py: integration tests against a real local Keystone instance with Lifesaver middleware enabled; covers all 6 auth method types (password, token body, token header, app-credential, S3, EC2), credit refill over time, and environment smoke tests
- Add E2E_TESTING_README.md: step-by-step setup instructions, required env vars, and example output
- Add test_env_vars.sh: environment variable template to source before running the E2E suite

check this [documentation](https://github.com/sapcc/keystone/blob/stable/2025.1-m3/CONTRIBUTING.md) if you want to run a keystone instance locally and execute the tests